### PR TITLE
Add Makefile for unified API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+PYTHON ?= python3
+VENV ?= .venv
+
+.PHONY: install api test run clean lint
+
+install:
+	$(PYTHON) -m venv $(VENV)
+	$(VENV)/bin/pip install -r requirements.txt
+
+api:
+	$(VENV)/bin/python demo_unified_api.py
+
+test:
+	$(VENV)/bin/pytest -vv
+
+run:
+	$(VENV)/bin/python backend/app.py
+
+lint:
+	$(VENV)/bin/flake8 backend core modules tests || true
+
+clean:
+	rm -rf $(VENV) **/__pycache__ .pytest_cache


### PR DESCRIPTION
## Summary
- add a Makefile to coordinate setup, running and testing the unified API

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement flask>=2.3.0)*
- `make test` *(fails: .venv/bin/pytest not found)*