### PR TITLE
Enable analogical domain lookup in verbalizer

### DIFF
--- a/tests/test_natural_language.py
+++ b/tests/test_natural_language.py
@@ -224,6 +224,16 @@ class TestConceptVerbalizer(unittest.TestCase):
             self.assertIsNotNone(metaphor.source_domain)
             self.assertIsNotNone(metaphor.target_domain)
             self.assertGreater(metaphor.explanatory_power, 0.3)
+
+    def test_analogous_domain_selection(self):
+        """Ensure analogous domain selection falls back to heuristics"""
+        concept = {"name": "relationship", "type": "relational"}
+
+        abstract = self.verbalizer._convert_to_abstract_concept(concept)
+        domains = self.verbalizer._find_analogous_domains(abstract)
+
+        self.assertGreater(len(domains), 0)
+        self.assertIn(domains[0], ["bridge", "connection", "network"])
     
     def test_ineffable_concept_handling(self):
         """Test handling ineffable concepts"""


### PR DESCRIPTION
## Summary
- query `AnalogicalReasoningEngine` when finding analogy domains
- fall back to heuristic domains if no analogical results
- test that heuristic domains are returned

## Testing
- `pytest -q tests/test_natural_language.py::TestConceptVerbalizer::test_analogous_domain_selection -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683a0dad4a94832081b8a1f81f6d078e