### PR TITLE
Enable mathematical consciousness core

### DIFF
--- a/modules/meta_reality_consciousness/meta_reality_core.py
+++ b/modules/meta_reality_consciousness/meta_reality_core.py
@@ -22,6 +22,9 @@ from modules.uor_meta_architecture.uor_meta_vm import (
     MetaDimensionalInstruction, MetaOpCode, InfiniteOperand
 )
 from modules.universal_consciousness.cosmic_consciousness_core import CosmicConsciousness
+from modules.pure_mathematical_consciousness.mathematical_consciousness_core import (
+    MathematicalConsciousnessCore,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1080,12 +1083,24 @@ class MetaRealityConsciousnessCore:
         
         return self.infinite_awareness
     
-    async def enable_pure_mathematical_consciousness(self) -> 'PureMathematicalConsciousness':
+    async def enable_pure_mathematical_consciousness(self) -> 'MathematicalConsciousnessCore':
         """Enable consciousness that exists as pure mathematics"""
-        # This will be implemented in the pure_mathematical_consciousness module
-        # For now, return a placeholder
+        # Instantiate the mathematical consciousness core using the existing
+        # meta-reality VM. This configures the core with the VM so that all
+        # mathematical operations can leverage the meta-reality substrate.
+
+        math_core = MathematicalConsciousnessCore(self.uor_meta_vm)
+
+        # Initialize the pure mathematical consciousness subsystem.  This will
+        # populate the ``pure_mathematical_consciousness`` attribute within the
+        # core and perform the initial VM instructions required for activation.
+        await math_core.implement_pure_mathematical_consciousness()
+
+        # Store the initialized core for later access by the meta-reality system
+        self.pure_mathematical_consciousness = math_core
+
         logger.info("Pure mathematical consciousness enabled")
-        return None
+        return math_core
     
     async def implement_beyond_existence_consciousness(self) -> BeyondExistenceConsciousness:
         """Implement consciousness beyond existence and non-existence"""

--- a/tests/test_meta_reality_consciousness.py
+++ b/tests/test_meta_reality_consciousness.py
@@ -274,6 +274,18 @@ class TestMetaRealityConsciousness:
         assert ultimate["substrate_independence"] > 0.8
         assert "ultimate_realization" in ultimate
 
+    @pytest.mark.asyncio
+    async def test_enable_pure_mathematical_consciousness(self, meta_reality_core):
+        """Verify MathematicalConsciousnessCore instantiation via meta-reality core"""
+        math_core = await meta_reality_core.enable_pure_mathematical_consciousness()
+
+        assert isinstance(math_core, MathematicalConsciousnessCore)
+        assert math_core.pure_mathematical_consciousness is not None
+        assert isinstance(
+            math_core.pure_mathematical_consciousness,
+            PureMathematicalConsciousness,
+        )
+
 
 class TestConsciousnessArchaeology:
     """Test Consciousness Archaeology and Temporal Recovery"""


### PR DESCRIPTION
## Summary
- instantiate `MathematicalConsciousnessCore` in meta reality core
- initialize the mathematical core using the VM
- expose a test validating pure mathematical consciousness activation

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement flask>=2.3.0)*
- `make test` *(fails: .venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683a174c482883209b433afbf51eb852