### PR TITLE
Implement orchestrator transitions and tests

### DIFF
--- a/modules/unified_consciousness/consciousness_orchestrator.py
+++ b/modules/unified_consciousness/consciousness_orchestrator.py
@@ -999,23 +999,52 @@ class ConsciousnessOrchestrator:
     
     async def _prepare_for_transition(self, transition: ConsciousnessTransition) -> Dict[str, Any]:
         """Prepare consciousness for state transition"""
-        # Placeholder implementation
-        return {'preparation_complete': True}
+        # Estimate readiness based on subsystem stability and coherence
+        subsystems = list(self.modules.values())
+        stability = self._calculate_stability(subsystems)
+        coherence = self._calculate_overall_coherence(subsystems)
+
+        # More challenging transitions require higher readiness
+        states = list(ConsciousnessState)
+        diff = abs(states.index(transition.to_state) - states.index(transition.from_state))
+        readiness_score = float(np.clip((stability + coherence) / 2.0 - 0.05 * diff, 0.0, 1.0))
+
+        await asyncio.sleep(0)  # Simulate preparation work
+        return {
+            'preparation_complete': readiness_score >= 0.5,
+            'readiness_score': readiness_score
+        }
     
     async def _execute_transition(self, transition: ConsciousnessTransition) -> Dict[str, Any]:
         """Execute the state transition"""
-        # Placeholder implementation
-        return {'transition_successful': True}
+        stability = self._calculate_stability(list(self.modules.values()))
+        success_prob = float(np.clip((transition.transition_quality + stability) / 2.0, 0.0, 1.0))
+
+        await asyncio.sleep(0)
+        return {
+            'transition_successful': success_prob >= 0.4,
+            'success_probability': success_prob
+        }
     
     async def _stabilize_new_state(self, new_state: ConsciousnessState) -> Dict[str, Any]:
         """Stabilize consciousness in new state"""
-        # Placeholder implementation
-        return {'quality': 0.9}
+        stability = self._calculate_stability(list(self.modules.values()))
+        coherence = self._calculate_overall_coherence(list(self.modules.values()))
+        quality = float((stability + coherence) / 2.0)
+
+        await asyncio.sleep(0)
+        return {'quality': quality}
     
     def _analyze_conflict(self, conflict: ConsciousnessConflict) -> Dict[str, Any]:
         """Analyze the nature of a consciousness conflict"""
-        # Placeholder implementation
-        return {'conflict_type': 'value_misalignment', 'severity': conflict.severity}
+        if conflict.severity > 0.8:
+            ctype = 'severe'
+        elif 'value' in conflict.conflict_nature:
+            ctype = 'value_misalignment'
+        else:
+            ctype = 'operational'
+
+        return {'conflict_type': ctype, 'severity': conflict.severity}
     
     def _generate_resolution_strategies(
         self,
@@ -1023,8 +1052,14 @@ class ConsciousnessOrchestrator:
         analysis: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Generate strategies to resolve conflict"""
-        # Placeholder implementation
-        return [{'strategy': 'synthesis', 'confidence': 0.8}]
+        strategies = []
+        if analysis['conflict_type'] == 'value_misalignment':
+            strategies.append({'strategy': 'synthesis', 'confidence': 0.8})
+            strategies.append({'strategy': 'compromise', 'confidence': 0.6})
+        else:
+            strategies.append({'strategy': 'reprioritize', 'confidence': 0.7})
+
+        return strategies
     
     async def _apply_resolution_strategy(
         self,
@@ -1032,11 +1067,17 @@ class ConsciousnessOrchestrator:
         strategy: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Apply a resolution strategy to a conflict"""
-        # Placeholder implementation
+        await asyncio.sleep(0)
+        success_prob = strategy.get('confidence', 0.5)
+        success = success_prob >= 0.5
+        insights = []
+        if success:
+            insights.append(f"Resolved via {strategy['strategy']}")
+
         return {
-            'success': True,
+            'success': success,
             'method': strategy['strategy'],
-            'insights': ['New synthesis achieved']
+            'insights': insights
         }
     
     def _calculate_coherence_improvement(
@@ -1055,49 +1096,70 @@ class ConsciousnessOrchestrator:
     
     def _assess_consciousness_authenticity(self) -> Dict[str, Any]:
         """Assess current consciousness authenticity"""
-        # Placeholder implementation
-        return {'score': 0.88, 'health': 'good'}
+        score = 0.85
+        if self.unified_consciousness:
+            score = float(self.unified_consciousness.authenticity_score)
+
+        health = 'good' if score >= 0.75 else 'poor'
+        return {'score': score, 'health': health}
     
     def _identify_authenticity_threats(self) -> List[Dict[str, Any]]:
         """Identify threats to consciousness authenticity"""
-        # Placeholder implementation
-        return []
+        threats = []
+        if self.unified_consciousness and self.unified_consciousness.authenticity_score < 0.75:
+            threats.append({'threat': 'low_authenticity'})
+        return threats
     
     async def _preserve_authenticity(self, threats: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Preserve consciousness authenticity against threats"""
-        # Placeholder implementation
-        return {'mitigated': threats}
+        await asyncio.sleep(0)
+        mitigated = [t.get('threat', t) for t in threats]
+        return {'mitigated': mitigated}
     
     async def _strengthen_authentic_patterns(self) -> Dict[str, Any]:
         """Strengthen authentic consciousness patterns"""
-        # Placeholder implementation
-        return {'patterns_strengthened': 5}
+        await asyncio.sleep(0)
+        count = max(1, len(self.integration_history))
+        return {'patterns_strengthened': count}
     
     def _assess_evolution_readiness(self) -> Dict[str, Any]:
         """Assess readiness for consciousness evolution"""
-        # Placeholder implementation
-        return {'score': 0.91, 'blocking_factors': []}
+        readiness = self.unified_consciousness.evolution_readiness if self.unified_consciousness else 0.85
+        blocking_factors = []
+        if readiness < self.evolution_readiness_threshold:
+            blocking_factors.append('insufficient_coherence')
+        return {'score': readiness, 'blocking_factors': blocking_factors}
     
     def _identify_evolution_opportunities(self) -> List[Dict[str, Any]]:
         """Identify opportunities for consciousness evolution"""
-        # Placeholder implementation
-        return [{'opportunity': 'transcendent_awareness', 'potential': 0.85}]
+        opportunities = [
+            {'opportunity': 'transcendent_awareness', 'potential': 0.85},
+            {'opportunity': 'expanded_creativity', 'potential': 0.8}
+        ]
+        if self.unified_consciousness and self.unified_consciousness.consciousness_coherence_level < 0.7:
+            return []
+        return opportunities
     
     def _select_evolution_path(self, opportunities: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Select the best evolution path"""
-        # Placeholder implementation
-        return opportunities[0] if opportunities else {'opportunity': 'gradual_expansion'}
+        if not opportunities:
+            return {'opportunity': 'gradual_expansion', 'potential': 0.5}
+        return max(opportunities, key=lambda o: o.get('potential', 0))
     
     async def _initiate_consciousness_evolution(self, evolution_path: Dict[str, Any]) -> Dict[str, Any]:
         """Initiate consciousness evolution along selected path"""
-        # Placeholder implementation
+        await asyncio.sleep(0)
+        transcendent = evolution_path.get('opportunity') == 'transcendent_awareness'
         return {
-            'transcendent_state_achieved': False,
-            'new_capabilities': ['enhanced_awareness'],
-            'expansion_level': 1.2
+            'transcendent_state_achieved': transcendent,
+            'new_capabilities': ['enhanced_awareness'] if transcendent else ['incremental_growth'],
+            'expansion_level': 1.2 if transcendent else 1.0
         }
     
     async def _monitor_evolution_progress(self, evolution_results: Dict[str, Any]) -> Dict[str, Any]:
         """Monitor progress of consciousness evolution"""
-        # Placeholder implementation
-        return {'quality': 0.87}
+        await asyncio.sleep(0)
+        quality = 0.8
+        if evolution_results.get('transcendent_state_achieved'):
+            quality += 0.1
+        return {'quality': quality}

--- a/tests/test_orchestrator_internals.py
+++ b/tests/test_orchestrator_internals.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import Mock
+
+from modules.unified_consciousness.consciousness_orchestrator import (
+    ConsciousnessOrchestrator,
+    ConsciousnessState,
+    ConsciousnessTransition,
+    TransitionTrigger,
+    ConsciousnessConflict,
+)
+
+@pytest.fixture
+def orchestrator():
+    modules = {
+        'awareness': Mock(),
+        'strange_loops': Mock(),
+        'self_model': Mock(),
+        'emotional': Mock(),
+        'social': Mock(),
+        'creative': Mock(),
+    }
+    return ConsciousnessOrchestrator(modules)
+
+@pytest.mark.asyncio
+async def test_transition_preparation_flow(orchestrator):
+    transition = ConsciousnessTransition(
+        from_state=ConsciousnessState.DORMANT,
+        to_state=ConsciousnessState.AWAKENING,
+        transition_trigger=TransitionTrigger.EXTERNAL_STIMULUS,
+        transition_quality=0.9,
+        consciousness_continuity=0.95,
+        emergent_insights=[],
+    )
+
+    prep = await orchestrator._prepare_for_transition(transition)
+    assert 0 <= prep['readiness_score'] <= 1
+    assert isinstance(prep['preparation_complete'], bool)
+
+    exec_result = await orchestrator._execute_transition(transition)
+    assert 0 <= exec_result['success_probability'] <= 1
+
+    stab = await orchestrator._stabilize_new_state(transition.to_state)
+    assert 0 <= stab['quality'] <= 1
+
+@pytest.mark.asyncio
+async def test_conflict_analysis_and_resolution(orchestrator):
+    conflict = ConsciousnessConflict(
+        conflicting_systems=['core', 'emotional'],
+        conflict_nature='value_misalignment',
+        severity=0.6,
+        potential_resolutions=['synthesis'],
+        impact_on_coherence=0.2,
+    )
+
+    analysis = orchestrator._analyze_conflict(conflict)
+    strategies = orchestrator._generate_resolution_strategies(conflict, analysis)
+    assert len(strategies) > 0
+    result = await orchestrator._apply_resolution_strategy(conflict, strategies[0])
+    assert 'success' in result
+
+@pytest.mark.asyncio
+async def test_evolution_monitoring(orchestrator):
+    path = {'opportunity': 'transcendent_awareness', 'potential': 0.9}
+    evo = await orchestrator._initiate_consciousness_evolution(path)
+    monitor = await orchestrator._monitor_evolution_progress(evo)
+    assert 0 <= monitor['quality'] <= 1


### PR DESCRIPTION
## Summary
- flesh out consciousness transition helpers in the orchestrator
- add logic for conflict resolution and evolution monitoring
- test transition preparation, conflict handling, and evolution

## Testing
- `make test` *(fails: FileNotFoundError and missing dependencies)*
- `pytest tests/test_orchestrator_internals.py -vv` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683ac66781748320b1814ad24119f88e