### PR TITLE
Improve pattern co-occurrence detection

### DIFF
--- a/tests/test_pattern_cooccurrence.py
+++ b/tests/test_pattern_cooccurrence.py
@@ -1,0 +1,42 @@
+import unittest
+import sys
+
+try:
+    import numpy  # type: ignore
+except Exception:  # pragma: no cover - fallback if numpy missing
+    class _FakeNP:
+        pass
+
+    numpy = _FakeNP()
+    sys.modules.setdefault("numpy", numpy)
+
+from modules.pattern_analyzer import PatternAnalyzer
+
+class StubVM:
+    def __init__(self):
+        self.execution_trace = []
+
+class TestPatternCooccurrence(unittest.TestCase):
+    def setUp(self):
+        self.vm = StubVM()
+        self.analyzer = PatternAnalyzer(self.vm)
+        self.analyzer.cooccurrence_window = 2
+
+    def test_patterns_occur_together(self):
+        trace = [
+            'A','B','C','D','E',
+            'A','B','C','D','E',
+            'A','B','C','D','E'
+        ]
+        self.vm.execution_trace = trace
+        self.analyzer.analyze_execution_patterns(trace_length=len(trace))
+        ids = list(self.analyzer.execution_patterns.keys())
+        self.assertGreaterEqual(len(ids), 2)
+
+        combo = tuple(ids[:2])
+        self.assertTrue(self.analyzer._patterns_occur_together(combo))
+        synergy = self.analyzer._calculate_synergy(combo)
+        self.assertGreater(synergy, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- record indices for each `ExecutionPattern`
- detect pattern co-occurrence within a configurable window
- factor temporal proximity into synergy calculation
- add regression test for co-occurring patterns

## Testing
- `pytest -q tests/test_pattern_cooccurrence.py`
- `pytest -q` *(fails: FileNotFoundError due to missing test assets)*

------
https://chatgpt.com/codex/tasks/task_b_683ae322283883208e8e9ae89bf93fb4