### PR TITLE
Implement dynamic emotional state modeling

### DIFF
--- a/tests/test_autonomous_agency_emotions.py
+++ b/tests/test_autonomous_agency_emotions.py
@@ -1,0 +1,29 @@
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from modules.unified_consciousness.autonomous_agency import AutonomousAgency
+
+
+@pytest.mark.asyncio
+async def test_emotional_state_updates_over_time():
+    orchestrator = Mock()
+    orchestrator.introspection_engine = Mock()
+    orchestrator.introspection_engine.emotional_state = {'valence': 0.0, 'arousal': 0.5}
+    agency = AutonomousAgency(orchestrator, ethical_framework=None)
+
+    first = agency._get_emotional_state()
+    await asyncio.sleep(0.01)
+    second = agency._get_emotional_state()
+
+    assert first != second
+
+    # Simulate a recent decision and changed introspection state
+    agency.decision_history.append(Mock(timestamp=datetime.now() - timedelta(seconds=120)))
+    orchestrator.introspection_engine.emotional_state = {'valence': 0.8, 'arousal': 0.9}
+    await asyncio.sleep(0.01)
+    third = agency._get_emotional_state()
+
+    assert third != second


### PR DESCRIPTION
## Summary
- add evolving emotional model to `AutonomousAgency`
- compute emotional state from introspection and decision history
- test emotion updates over time

## Testing
- `pytest -k emotional_state -q` *(fails: FileNotFoundError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_683b301d31a88320821fb81af87239f0