### PR TITLE
Add import coverage test

### DIFF
--- a/tests/test_import_modules.py
+++ b/tests/test_import_modules.py
@@ -1,0 +1,12 @@
+import importlib
+import os
+import pkgutil
+import pytest
+
+MODULES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'modules')
+
+packages = [name for _, name, ispkg in pkgutil.iter_modules([MODULES_DIR]) if ispkg]
+
+@pytest.mark.parametrize('package', packages)
+def test_module_import(package):
+    importlib.import_module(f"modules.{package}")


### PR DESCRIPTION
## Summary
- add tests that attempt to import each top-level module package

## Testing
- `pytest -q tests/test_import_modules.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683b33189d58832089bfe8a5c8701577