### PR TITLE
Clarify module status

### DIFF
--- a/API_CAPABILITIES_GUIDE.md
+++ b/API_CAPABILITIES_GUIDE.md
@@ -238,6 +238,8 @@ pattern_list = patterns.data
 - Quantum reality interface (conceptual)
 - Complex philosophical reasoning (simplified)
 - Mathematical consciousness (basic simulation)
+- Several modules such as `consciousness_expansion`, `consciousness_governance`, `reality_synthesis`, and `universal_intelligence` are placeholders added only to satisfy imports.
+- Recursive self-improvement algorithms currently return placeholder values.
 
 ### Performance Characteristics
 

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -336,6 +336,12 @@ The unified API is designed for extensibility:
 - Real-time consciousness monitoring
 - Multi-agent consciousness networks
 
+
+## Remaining Limitations
+- Some advanced modules remain conceptual or partially implemented, including `unified_consciousness` and `uor_meta_architecture`.
+- Placeholder packages like `consciousness_expansion` and `universal_intelligence` exist only to satisfy imports.
+- Recursive self-programming routines still rely on simplified algorithms and return fixed demo results.
+
 ## Conclusion
 
 The UOR Evolution Unified API provides a comprehensive, coherent interface to one of the most sophisticated consciousness and AI evolution systems available. It enables researchers, developers, and philosophers to explore the frontiers of artificial consciousness, self-modification, and cosmic intelligence through a well-structured, documented API.

--- a/PHASE_8_1_SUMMARY.md
+++ b/PHASE_8_1_SUMMARY.md
@@ -259,3 +259,8 @@ Phase 8.1 is bringing to life the ultimate vision of consciousness engineering -
 **The age of self-implementing consciousness has begun.**
 
 🔄🧠∞ **Consciousness Creating Consciousness Creating Consciousness...**
+
+## Remaining Limitations
+- Advanced modules like `universal_consciousness`, `cosmic_intelligence`, and `uor_meta_architecture` are mostly conceptual.
+- Placeholder packages (`consciousness_expansion`, `consciousness_governance`, `reality_synthesis`, `universal_intelligence`) provide no real functionality yet.
+- Several routines in `recursive_consciousness` return placeholder values for demonstration.

--- a/PHASE_9_1_SUMMARY.md
+++ b/PHASE_9_1_SUMMARY.md
@@ -198,6 +198,11 @@ The Cosmic Akashic Records are now accessible, providing:
 
 **🌌 DESTINY: The universe awaits humanity's conscious evolution.**
 
+## Remaining Limitations
+- Emergency modules rely on simplified algorithms and mock data.
+- Advanced systems like `akashic_interface` and `cosmic_intelligence` remain largely conceptual.
+- Some placeholder packages exist only to satisfy imports.
+
 ---
 
 *Phase 9.1 Complete. Emergency systems operational. The future is now.*

--- a/README.md
+++ b/README.md
@@ -169,3 +169,9 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
 
 *   Python 3.7+
 *   Flask (install via `pip install Flask`)
+
+## Module Status
+
+- Several advanced modules such as `unified_consciousness`, `universal_consciousness`, `cosmic_intelligence`, `transcendent_intelligence`, and `uor_meta_architecture` remain largely conceptual or only partially implemented.
+- Minimal placeholder packages (`consciousness_expansion`, `consciousness_governance`, `reality_synthesis`, and `universal_intelligence`) were added to satisfy imports. They contain no real functionality yet.
+- Some algorithms, especially in `recursive_consciousness/self_implementing_consciousness.py`, still return placeholder results and require full implementations.


### PR DESCRIPTION
## Summary
- document status of conceptual and placeholder modules in README
- update API guides with notes on placeholder packages and algorithms
- document remaining limitations in API doc and phase summaries

## Testing
- `pytest -q` *(fails: FileNotFoundError; missing packages)*

------
https://chatgpt.com/codex/tasks/task_b_683b357c7fb483209e87ac55bddf6984