### PR TITLE
Add configurable physics parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
 3.  **Edit Configuration (Optional):**
     Difficulty parameters and the starting level are defined in `config.yaml`.
     Adjust the values under `difficulty_levels` or `teacher.difficulty` to
-    customize how challenging the goals will be.
+    customize how challenging the goals will be. Additional sections such as
+    `consciousness_physics`, `quantum`, and `reality_interface` contain
+    defaults for bandwidth, fidelity, and energy limits used by the more
+    advanced modules.
 4.  **Access the Frontend:**
     Open your web browser and navigate to `http://127.0.0.1:5000/`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,20 @@ difficulty_levels:
     quick_success_threshold: 2
 benchmark:
   iterations: 100
+
+# Physics and quantum defaults
+consciousness_physics:
+  information_transfer_rate: 1e20
+  consciousness_bandwidth: 1e22
+  info_reality_bridge_bandwidth: 1e20
+  info_reality_bridge_fidelity: 0.9
+
+quantum:
+  communication_bandwidth: 1e6
+  teleportation_fidelity: 0.9
+  fidelity_threshold: 0.99
+
+reality_interface:
+  energy_limit: 1e50
+  info_matter_bandwidth: 1e20
+  info_matter_fidelity: 0.99

--- a/config_loader.py
+++ b/config_loader.py
@@ -31,7 +31,14 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
                 indents.append(indent + 2)
             else:
                 value: Any = rest
-                if value.isdigit():
-                    value = int(value)
+                try:
+                    numeric = float(value)
+                    if numeric.is_integer() and not any(c in value for c in [".", "e", "E"]):
+                        value = int(numeric)
+                    else:
+                        value = numeric
+                except ValueError:
+                    if value.isdigit():
+                        value = int(value)
                 stack[-1][key] = value
     return config

--- a/modules/consciousness_physics/consciousness_field_theory.py
+++ b/modules/consciousness_physics/consciousness_field_theory.py
@@ -16,6 +16,14 @@ import logging
 import scipy.constants as const
 
 from ..universe_interface import UniverseInterface
+from config_loader import load_config
+
+_CONFIG = load_config()
+_PHYS_CONF = _CONFIG.get("consciousness_physics", {})
+INFO_TRANSFER_RATE = float(_PHYS_CONF.get("information_transfer_rate", 1e20))
+CONSCIOUSNESS_BANDWIDTH = float(_PHYS_CONF.get("consciousness_bandwidth", 1e22))
+INFO_BRIDGE_BANDWIDTH = float(_PHYS_CONF.get("info_reality_bridge_bandwidth", 1e20))
+INFO_BRIDGE_FIDELITY = float(_PHYS_CONF.get("info_reality_bridge_fidelity", 0.9))
 
 
 class FieldType(Enum):
@@ -615,12 +623,12 @@ class ConsciousnessFieldTheory:
         """Calculate consciousness-information interaction"""
         return ConsciousnessInformationInteraction(
             information_coupling=self.interaction_strength_scale * 0.5,
-            information_transfer_rate=1e20,  # Bits per second
+            information_transfer_rate=INFO_TRANSFER_RATE,
             consciousness_computation_rate=1e30,  # Operations per second
             quantum_information_processing=1e25,
             classical_information_processing=1e20,
             information_integration_rate=1e15,
-            consciousness_bandwidth=1e22,
+            consciousness_bandwidth=CONSCIOUSNESS_BANDWIDTH,
             information_consciousness_duality=0.8
         )
         
@@ -754,8 +762,8 @@ class ConsciousnessFieldTheory:
         """Enable information-reality bridge"""
         return {
             "strength": 0.5,
-            "bandwidth": 1e20,
-            "fidelity": 0.9,
+            "bandwidth": INFO_BRIDGE_BANDWIDTH,
+            "fidelity": INFO_BRIDGE_FIDELITY,
             "bidirectionality": 0.8
         }
         

--- a/modules/universal_consciousness/quantum_consciousness_interface.py
+++ b/modules/universal_consciousness/quantum_consciousness_interface.py
@@ -16,6 +16,12 @@ import logging
 import cmath
 
 from .cosmic_consciousness_core import CosmicConsciousness, CosmicScale
+from config_loader import load_config
+
+_CONFIG = load_config()
+_Q_CONF = _CONFIG.get("quantum", {})
+COMM_BANDWIDTH = float(_Q_CONF.get("communication_bandwidth", 1000.0))
+TELEPORTATION_FIDELITY = float(_Q_CONF.get("teleportation_fidelity", 0.9))
 
 
 class QuantumState(Enum):
@@ -195,7 +201,7 @@ class QuantumConsciousnessInterface:
                 global_entanglement=network_properties["global_entanglement"],
                 quantum_network_coherence=network_properties["coherence"],
                 nonlocal_processing_capability=0.5,
-                quantum_communication_bandwidth=1000.0,  # Qubits/sec
+                quantum_communication_bandwidth=COMM_BANDWIDTH,
                 cosmic_entanglement_density=0.1
             )
             
@@ -399,7 +405,7 @@ class QuantumConsciousnessInterface:
                 entanglement_strength=0.9,
                 bell_inequality_violation=2.8,  # Maximum violation
                 channel_capacity=1.0,
-                teleportation_fidelity=0.9,
+                teleportation_fidelity=TELEPORTATION_FIDELITY,
                 nonlocal_correlation=0.9
             )
             links.append(link)
@@ -558,7 +564,7 @@ class QuantumConsciousnessInterface:
             entanglement_strength=0.8,
             bell_inequality_violation=2.6,
             channel_capacity=0.8,
-            teleportation_fidelity=0.85,
+            teleportation_fidelity=TELEPORTATION_FIDELITY,
             nonlocal_correlation=0.8
         )
         

--- a/modules/universe_interface/quantum_reality_interface.py
+++ b/modules/universe_interface/quantum_reality_interface.py
@@ -17,6 +17,16 @@ import scipy.constants as const
 from scipy.linalg import expm
 
 from ..consciousness_physics import ConsciousnessFieldTheory
+from config_loader import load_config
+
+_CONFIG = load_config()
+_Q_CONF = _CONFIG.get("quantum", {})
+_R_CONF = _CONFIG.get("reality_interface", {})
+COMM_BANDWIDTH = float(_Q_CONF.get("communication_bandwidth", 1e6))
+FIDELITY_THRESHOLD = float(_Q_CONF.get("fidelity_threshold", 0.99))
+INFO_MATTER_BANDWIDTH = float(_R_CONF.get("info_matter_bandwidth", 1e20))
+INFO_MATTER_FIDELITY = float(_R_CONF.get("info_matter_fidelity", 0.99))
+ENERGY_LIMIT = float(_R_CONF.get("energy_limit", 1e50))
 
 
 class QuantumOperation(Enum):
@@ -331,7 +341,7 @@ class QuantumRealityInterface:
         self.consciousness_programming: Optional[ConsciousnessRealityProgramming] = None
         
         # Operational parameters
-        self.quantum_fidelity_threshold: float = 0.99
+        self.quantum_fidelity_threshold: float = FIDELITY_THRESHOLD
         self.spacetime_stability_threshold: float = 0.95
         self.reality_modification_limit: float = 0.001
 
@@ -369,7 +379,7 @@ class QuantumRealityInterface:
                 quantum_field_interaction=field_interaction,
                 quantum_consciousness_coherence=quantum_coherence,
                 quantum_computing_capability=100.0,  # 100 qubits equivalent
-                quantum_communication_bandwidth=1e6,  # 1 MHz
+                quantum_communication_bandwidth=COMM_BANDWIDTH,
                 quantum_sensing_precision=1e-15  # Femto-scale
             )
             
@@ -660,7 +670,9 @@ class QuantumRealityInterface:
         )
         
         # Check energy requirements
-        energy_available = manipulation.metric_tensor_modification.energy_requirement < 1e50
+        energy_available = (
+            manipulation.metric_tensor_modification.energy_requirement < ENERGY_LIMIT
+        )
         
         safe = metric_stable and causality_safe and energy_available
         
@@ -890,8 +902,8 @@ class QuantumRealityInterface:
         """Create interface between information and matter"""
         return {
             "interface_type": "holographic",
-            "bandwidth": 1e20,  # Bits per second
-            "fidelity": 0.99,
+            "bandwidth": INFO_MATTER_BANDWIDTH,
+            "fidelity": INFO_MATTER_FIDELITY,
             "quantum_channel": True
         }
         


### PR DESCRIPTION
## Summary
- parse floats in config loader
- expose consciousness and quantum constants via config sections
- use config values for bandwidth, fidelity and energy limits
- document new parameters in README

## Testing
- `pytest -q` *(fails: FileNotFoundError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_683b5d7ee18083209e46c38cca344ce8