### PR TITLE
Resolve UOR placeholders

### DIFF
--- a/tests/test_goal_seeker_placeholders.py
+++ b/tests/test_goal_seeker_placeholders.py
@@ -1,0 +1,30 @@
+import pytest
+from generate_goal_seeker_uor import generate_goal_seeker_program
+from phase1_vm_enhancements import chunk_push, parse_opcode_and_operand, OP_PUSH
+
+
+def test_placeholder_resolution():
+    program, meta = generate_goal_seeker_program(return_debug=True)
+
+    labels = meta['labels']
+    jump_placeholders = meta['jump_placeholders']
+    slot_placeholders = meta['slot_placeholders']
+    selected_addresses = meta['selected_addresses']
+
+    mapping = {
+        'dynamic_slot_choice': selected_addresses[0],
+        'default_lsc_success': selected_addresses[1],
+        'lsc_carry': selected_addresses[2],
+        'lsc_failure': selected_addresses[3],
+    }
+
+    for idx, label in jump_placeholders:
+        opcode, operand = parse_opcode_and_operand(program[idx])
+        assert opcode == OP_PUSH
+        assert operand == labels[label]
+
+    for key, idx in slot_placeholders.items():
+        opcode, operand = parse_opcode_and_operand(program[idx])
+        assert opcode == OP_PUSH
+        assert operand == mapping[key]
+


### PR DESCRIPTION
## Summary
- centralize placeholder resolution logic for the goal seeker UOR generator
- validate that no placeholders remain after generation
- support returning metadata about placeholder indices
- test that jump and slot placeholders are replaced correctly

## Testing
- `pytest tests/test_goal_seeker_placeholders.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683b628030c483208422562ea492543a