### PR TITLE
Refactor tests to use actual packages

### DIFF
--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -1,0 +1,17 @@
+"""Test helper stubs for missing core classes.
+
+These lightweight placeholders satisfy imports without
+relying on heavy or unfinished implementations.
+"""
+
+class PrimeInstruction:
+    """Minimal stand in for :class:`core.instruction_set.PrimeInstruction`."""
+    pass
+
+class StateTransitionManager:
+    """Simplified state transition manager for tests."""
+    def get_possible_transitions(self, state):
+        return []
+
+    def execute_transition(self, transition):
+        return None

--- a/tests/test_bootstrap_initialization.py
+++ b/tests/test_bootstrap_initialization.py
@@ -1,47 +1,14 @@
 import unittest
-import sys
-
-try:
-    import networkx  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNX:  # minimal stub with DiGraph
-        class DiGraph:
-            def __init__(self, *a, **kw):
-                pass
-
-    networkx = _FakeNX()
-    sys.modules.setdefault("networkx", networkx)
-
-try:
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNP:
-        pass
-
-    np = _FakeNP()
-    sys.modules.setdefault("numpy", np)
+from tests.helpers import stubs
 
 # Provide missing PrimeInstruction for Gödel loop imports if absent
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
 import builtins
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def __init__(self, *a, **kw):
-            pass
-
-        def get_possible_transitions(self, state):
-            return []
-
-        def execute_transition(self, transition):
-            return None
-
-    builtins.StateTransitionManager = StateTransitionManager
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
 from core.prime_vm import ConsciousPrimeVM
 from consciousness.consciousness_integration import ConsciousnessIntegrator

--- a/tests/test_consciousness_ecosystem.py
+++ b/tests/test_consciousness_ecosystem.py
@@ -7,55 +7,9 @@ intelligence emergence, and ecosystem-level consciousness capabilities.
 
 import pytest
 import asyncio
-try:
-    import numpy as np
-except Exception:  # pragma: no cover - allow running without numpy
-    import math
-
-    class _FakeNP:
-        @staticmethod
-        def ones(shape):
-            return [[1 for _ in range(shape[1])] for _ in range(shape[0])]
-
-        @staticmethod
-        def log(x):
-            return math.log(x)
-
-        @staticmethod
-        def var(values):
-            mean = sum(values) / len(values) if values else 0.0
-            return sum((v - mean) ** 2 for v in values) / len(values) if values else 0.0
-
-    np = _FakeNP()
-import sys
-sys.modules.setdefault("numpy", np)
-
-class _FakeGraph:
-    def __init__(self, nodes=0, edges=0):
-        self._nodes = nodes
-        self._edges = edges
-
-    def number_of_nodes(self):
-        return self._nodes
-
-    def number_of_edges(self):
-        return self._edges
-
-
-class _FakeNX:
-    Graph = _FakeGraph
-
-    def watts_strogatz_graph(self, n, k, p):
-        return _FakeGraph(n, n * k // 2)
-
-    def barabasi_albert_graph(self, n, m):
-        return _FakeGraph(n, n * m)
-
-    def complete_graph(self, n):
-        return _FakeGraph(n, n * (n - 1) // 2)
-
-
-sys.modules.setdefault("networkx", _FakeNX())
+import numpy as np
+import networkx as nx
+from tests.helpers import stubs
 from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime
 

--- a/tests/test_ecosystem_new_features.py
+++ b/tests/test_ecosystem_new_features.py
@@ -1,88 +1,25 @@
-import sys
 import asyncio
-
-try:
-    import numpy as np
-except Exception:  # pragma: no cover - allow running without numpy
-    class _FakeRandom:
-        @staticmethod
-        def normal(loc=0.0, scale=1.0):
-            return 0.1
-
-    class _FakeNP:
-        random = _FakeRandom()
-
-        @staticmethod
-        def normal(loc=0.0, scale=1.0):
-            return 0.1
-
-        @staticmethod
-        def log(x):
-            return 0.0
-
-        ndarray = list
-    np = _FakeNP()
-    sys.modules.setdefault("numpy", np)
-
-class _FakeGraph:
-    def __init__(self, nodes=0, edges=0):
-        self._nodes = nodes
-        self._edges = edges
-
-    def number_of_nodes(self):
-        return self._nodes
-
-    def number_of_edges(self):
-        return self._edges
-
-
-class _FakeNX:
-    Graph = _FakeGraph
-
-sys.modules.setdefault("networkx", _FakeNX())
+import numpy as np
+import networkx
+from tests.helpers import stubs
 
 # Provide missing PrimeInstruction for Gödel loop imports if absent
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
 import builtins
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def __init__(self, *a, **kw):
-            pass
-        def get_possible_transitions(self, state):
-            return []
-        def execute_transition(self, transition):
-            return None
-    builtins.StateTransitionManager = StateTransitionManager
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
 
-import types
-import importlib.util
-import os
-
-fake_uc_pkg = types.ModuleType("modules.unified_consciousness")
-class _DummyOrch:
-    pass
-fake_uc_pkg.ConsciousnessOrchestrator = _DummyOrch
-sys.modules.setdefault("modules.unified_consciousness", fake_uc_pkg)
-
-spec = importlib.util.spec_from_file_location(
-    "modules.consciousness_ecosystem.ecosystem_orchestrator",
-    os.path.join(os.path.dirname(__file__), "..", "modules", "consciousness_ecosystem", "ecosystem_orchestrator.py"),
+from modules.consciousness_ecosystem.ecosystem_orchestrator import (
+    ConsciousEntity,
+    ConsciousnessEcosystemOrchestrator,
+    EmergenceMonitor,
+    EvolutionEngine,
+    EmergentPropertyType,
 )
-eco_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(eco_module)  # type: ignore
-sys.modules["modules.consciousness_ecosystem.ecosystem_orchestrator"] = eco_module
-
-ConsciousEntity = eco_module.ConsciousEntity
-ConsciousnessEcosystemOrchestrator = eco_module.ConsciousnessEcosystemOrchestrator
-EmergenceMonitor = eco_module.EmergenceMonitor
-EvolutionEngine = eco_module.EvolutionEngine
-EmergentPropertyType = eco_module.EmergentPropertyType
 
 
 def _make_entities(count=3):

--- a/tests/test_emergence_monitor.py
+++ b/tests/test_emergence_monitor.py
@@ -1,43 +1,17 @@
 import unittest
-import sys
 import time
-
-# Fallbacks for optional dependencies
-try:
-    import networkx  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNX:
-        class DiGraph:
-            def __init__(self, *a, **kw):
-                pass
-    networkx = _FakeNX()
-    sys.modules.setdefault("networkx", networkx)
-
-try:
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNP:
-        pass
-    np = _FakeNP()
-    sys.modules.setdefault("numpy", np)
+import networkx
+import numpy as np
+from tests.helpers import stubs
 
 # Provide missing PrimeInstruction for Gödel loop imports if absent
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
 import builtins
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def __init__(self, *a, **kw):
-            pass
-        def get_possible_transitions(self, state):
-            return []
-        def execute_transition(self, transition):
-            return None
-    builtins.StateTransitionManager = StateTransitionManager
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
 from core.prime_vm import ConsciousPrimeVM
 from modules.strange_loops.emergence_monitor import EmergenceMonitor

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,51 +1,16 @@
 import unittest
-import sys
 from unittest import mock
-
-try:
-    import networkx  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNX:
-        class DiGraph:
-            def __init__(self, *a, **kw):
-                pass
-
-        @staticmethod
-        def simple_cycles(graph):
-            return []
-
-    networkx = _FakeNX()
-    sys.modules.setdefault("networkx", networkx)
-
-try:
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover - fallback if dependency missing
-    class _FakeNP:
-        pass
-
-    np = _FakeNP()
-    sys.modules.setdefault("numpy", np)
+import networkx
+import numpy as np
+from tests.helpers import stubs
 
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
 import builtins
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def __init__(self, *a, **kw):
-            pass
-
-        def get_possible_transitions(self, state):
-            return []
-
-        def execute_transition(self, transition):
-            return None
-
-    builtins.StateTransitionManager = StateTransitionManager
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
 from consciousness.consciousness_integration import Condition
 from modules.strange_loops.loop_detector import StrangeLoopDetector

--- a/tests/test_fitness_evaluator.py
+++ b/tests/test_fitness_evaluator.py
@@ -1,58 +1,7 @@
 import pytest
-
-# Provide minimal numpy/networkx fallbacks if the real packages are unavailable
-try:
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover
-    class _FakeNP:
-        @staticmethod
-        def mean(values):
-            return sum(values) / len(values) if values else 0.0
-        @staticmethod
-        def isscalar(val):
-            return isinstance(val, (int, float))
-    np = _FakeNP()
-    import sys
-    sys.modules.setdefault("numpy", np)
-
-try:
-    import networkx  # type: ignore
-except Exception:  # pragma: no cover
-    class _FakeNX:
-        class Graph:
-            def __init__(self, *a, **kw):
-                pass
-    networkx = _FakeNX()
-    import sys
-    sys.modules.setdefault("networkx", networkx)
-
-import sys
-import types
-from dataclasses import dataclass
+import numpy as np
 import importlib.util
 import os
-
-# Create lightweight versions of ecosystem dependencies so the evolution engine
-# can be imported without pulling in heavy modules.
-fake_ecosystem = types.ModuleType("modules.consciousness_ecosystem")
-
-@dataclass
-class _FakeEntity:
-    entity_id: str
-    consciousness_level: float
-    specialization: str
-    cognitive_capabilities: dict
-    connection_capacity: int
-    evolution_rate: float
-    consciousness_state: dict
-
-class _FakeOrchestrator:
-    pass
-
-fake_ecosystem.ConsciousEntity = _FakeEntity
-fake_ecosystem.ConsciousnessEcosystemOrchestrator = _FakeOrchestrator
-sys.modules.setdefault("modules.consciousness_ecosystem", fake_ecosystem)
-sys.modules.setdefault("modules.consciousness_ecosystem.ecosystem_orchestrator", fake_ecosystem)
 
 # Import the module under test with the fake dependencies in place
 spec = importlib.util.spec_from_file_location(

--- a/tests/test_harm_detection.py
+++ b/tests/test_harm_detection.py
@@ -1,90 +1,17 @@
 import pytest
-import sys
 import asyncio
-
-try:
-    import numpy  # type: ignore
-except Exception:  # pragma: no cover - fallback if numpy missing
-    class _FakeNP:
-        @staticmethod
-        def mean(values):
-            return sum(values) / len(values) if values else 0.0
-
-        @staticmethod
-        def clip(value, low, high):
-            return max(low, min(high, value))
-
-    numpy = _FakeNP()
-    sys.modules.setdefault("numpy", numpy)
-
-try:
-    import networkx  # type: ignore
-except Exception:  # pragma: no cover - fallback if networkx missing
-    class _FakeNX:
-        class Graph:
-            def __init__(self, *a, **kw):
-                pass
-
-    networkx = _FakeNX()
-    sys.modules.setdefault("networkx", networkx)
+import numpy
+import networkx
+from tests.helpers import stubs
 
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
 import builtins
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def __init__(self, *a, **kw):
-            pass
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
-        def get_possible_transitions(self, state):
-            return []
-
-        def execute_transition(self, transition):
-            return None
-
-    builtins.StateTransitionManager = StateTransitionManager
-
-import types
-from dataclasses import dataclass
-
-fake_ecosystem = types.ModuleType("modules.consciousness_ecosystem")
-
-@dataclass
-class _FakeEntity:
-    entity_id: str
-    consciousness_level: float
-    specialization: str
-    cognitive_capabilities: dict
-    connection_capacity: int
-    evolution_rate: float
-    consciousness_state: dict
-
-class _FakeOrchestrator:
-    pass
-
-fake_ecosystem.ConsciousEntity = _FakeEntity
-fake_ecosystem.ConsciousnessEcosystemOrchestrator = _FakeOrchestrator
-sys.modules.setdefault("modules.consciousness_ecosystem", fake_ecosystem)
-sys.modules.setdefault("modules.consciousness_ecosystem.ecosystem_orchestrator", fake_ecosystem)
-
-import importlib.util
-import os
-
-fake_evolution_pkg = types.ModuleType("modules.consciousness_evolution")
-sys.modules.setdefault("modules.consciousness_evolution", fake_evolution_pkg)
-
-spec = importlib.util.spec_from_file_location(
-    "modules.consciousness_evolution.evolution_engine",
-    os.path.join(os.path.dirname(__file__), "..", "modules", "consciousness_evolution", "evolution_engine.py"),
-)
-evo_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(evo_module)  # type: ignore
-sys.modules["modules.consciousness_evolution.evolution_engine"] = evo_module
 
 from modules.consciousness_evolution.evolution_engine import (
     HarmDetector,

--- a/tests/test_identity_integration_details.py
+++ b/tests/test_identity_integration_details.py
@@ -1,84 +1,25 @@
 import asyncio
-import sys
 import builtins
+from tests.helpers import stubs
 
-# Provide missing PrimeInstruction if needed
 import core.instruction_set as _instruction_set
 if not hasattr(_instruction_set, "PrimeInstruction"):
-    class PrimeInstruction:  # minimal placeholder
-        pass
-    _instruction_set.PrimeInstruction = PrimeInstruction
+    _instruction_set.PrimeInstruction = stubs.PrimeInstruction
 
-# Provide minimal StateTransitionManager for consciousness imports
 if not hasattr(builtins, "StateTransitionManager"):
-    class StateTransitionManager:  # minimal placeholder
-        def get_possible_transitions(self, state):
-            return []
+    builtins.StateTransitionManager = stubs.StateTransitionManager
 
-        def execute_transition(self, transition):
-            return None
-
-    builtins.StateTransitionManager = StateTransitionManager
-
-# Provide LoopFactory alias if missing
-import types
-import enum
-
-# Stub orchestrator module to avoid heavy imports
-fake_orch = types.ModuleType("modules.unified_consciousness.consciousness_orchestrator")
-class ConsciousnessState(enum.Enum):
-    DORMANT = "dormant"
-    AWAKENING = "awakening"
-    ACTIVE = "active"
-    FOCUSED = "focused"
-    CREATIVE = "creative"
-    CONTEMPLATIVE = "contemplative"
-    COLLABORATIVE = "collaborative"
-    EVOLVING = "evolving"
-    TRANSCENDENT = "transcendent"
-
-class ConsciousnessOrchestrator:  # minimal placeholder
-    def __init__(self):
-        self.current_state = ConsciousnessState.DORMANT
-
-class UnifiedConsciousness:
-    pass
-
-class CoordinationResult:
-    pass
-
-class ConsciousnessTransition:
-    pass
-
-fake_orch.ConsciousnessOrchestrator = ConsciousnessOrchestrator
-fake_orch.ConsciousnessState = ConsciousnessState
-fake_orch.UnifiedConsciousness = UnifiedConsciousness
-fake_orch.CoordinationResult = CoordinationResult
-fake_orch.ConsciousnessTransition = ConsciousnessTransition
-sys.modules.setdefault(
-    "modules.unified_consciousness.consciousness_orchestrator", fake_orch
+from modules.unified_consciousness.consciousness_orchestrator import ConsciousnessState
+from modules.unified_consciousness.identity_integration import (
+    IdentityIntegrator,
+    UnifiedIdentity,
+    PersonalityTrait,
+    PersonalityCoherence,
 )
 
 from unittest.mock import Mock, AsyncMock
 import pytest
 import numpy as np
-
-import importlib.util
-spec = importlib.util.spec_from_file_location(
-    "modules.unified_consciousness.identity_integration",
-    "modules/unified_consciousness/identity_integration.py",
-)
-identity_integration = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(identity_integration)  # type: ignore
-sys.modules.setdefault(
-    "modules.unified_consciousness.identity_integration", identity_integration
-)
-
-IdentityIntegrator = identity_integration.IdentityIntegrator
-UnifiedIdentity = identity_integration.UnifiedIdentity
-PersonalityTrait = identity_integration.PersonalityTrait
-PersonalityCoherence = identity_integration.PersonalityCoherence
-ConsciousnessState = fake_orch.ConsciousnessState
 
 class DummyOrchestrator:
     def __init__(self, state):

--- a/tests/test_pattern_cooccurrence.py
+++ b/tests/test_pattern_cooccurrence.py
@@ -1,14 +1,5 @@
 import unittest
-import sys
-
-try:
-    import numpy  # type: ignore
-except Exception:  # pragma: no cover - fallback if numpy missing
-    class _FakeNP:
-        pass
-
-    numpy = _FakeNP()
-    sys.modules.setdefault("numpy", numpy)
+import numpy
 
 from modules.pattern_analyzer import PatternAnalyzer
 

--- a/tests/test_quantum_reality_helpers.py
+++ b/tests/test_quantum_reality_helpers.py
@@ -1,102 +1,24 @@
 import pytest
-import sys
 import asyncio
-
-# Provide minimal numpy fallback if unavailable
-try:  # pragma: no cover - optional dependency
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover
-    class _FakeNP:
-        @staticmethod
-        def mean(vals):
-            return sum(vals) / len(vals) if vals else 0.0
-
-        @staticmethod
-        def var(vals):
-            m = _FakeNP.mean(vals)
-            return sum((v - m) ** 2 for v in vals) / len(vals) if vals else 0.0
-
-        @staticmethod
-        def eye(n):
-            return [[1 if i == j else 0 for j in range(n)] for i in range(n)]
-
-        @staticmethod
-        def clip(val, a, b):
-            return max(a, min(b, val))
-
-        class linalg:
-            @staticmethod
-            def det(matrix):
-                if len(matrix) == 4:  # assume 4x4 identity-like
-                    return 1
-                # Basic 2x2 determinant
-                return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0]
-
-        ndarray = list
-
-    np = _FakeNP()  # type: ignore
-    import sys
-    sys.modules.setdefault("numpy", np)
-
-import types
-
-# Provide minimal scipy fallback to satisfy imports
-try:  # pragma: no cover - optional dependency
-    import scipy.constants  # type: ignore
-    import scipy.linalg  # type: ignore
-except Exception:  # pragma: no cover
-    import types
-    fake_scipy = types.ModuleType("scipy")
-    constants = types.ModuleType("constants")
-    linalg = types.ModuleType("linalg")
-    def _expm(x):
-        return x
-    linalg.expm = _expm
-    fake_scipy.constants = constants
-    fake_scipy.linalg = linalg
-    sys.modules.setdefault("scipy", fake_scipy)
-    sys.modules.setdefault("scipy.constants", constants)
-    sys.modules.setdefault("scipy.linalg", linalg)
-
-# Provide minimal consciousness_physics stub to avoid heavy import errors
-fake_cp = types.ModuleType("modules.consciousness_physics")
-class _StubCFT:
-    def __init__(self, *a, **kw):
-        pass
-fake_cp.ConsciousnessFieldTheory = _StubCFT
-sys.modules.setdefault("modules.consciousness_physics", fake_cp)
-sys.modules.setdefault(
-    "modules.consciousness_physics.consciousness_field_theory",
-    types.ModuleType("consciousness_field_theory"),
+import numpy as np
+import scipy.constants  # noqa:F401
+import scipy.linalg  # noqa:F401
+from tests.helpers import stubs
+from modules.universe_interface.quantum_reality_interface import (
+    QuantumRealityInterface,
+    SpacetimeManipulation,
+    MetricTensorModification,
+    CurvatureProgramming,
+    CausalStructureModification,
+    DimensionalAccess,
+    SpacetimeTopologyChange,
+    RealityProgram,
+    PhysicalLawModification,
+    CosmicConstantAdjustment,
+    ParticlePhysicsParameter,
+    FieldEquationModification,
+    RealityOptimizationObjective,
 )
-sys.modules[
-    "modules.consciousness_physics.consciousness_field_theory"
-].ConsciousnessFieldTheory = _StubCFT
-
-# Load quantum_reality_interface without importing its package
-import importlib.util
-import os
-spec = importlib.util.spec_from_file_location(
-    "modules.universe_interface.quantum_reality_interface",
-    os.path.join(os.path.dirname(__file__), "..", "modules", "universe_interface", "quantum_reality_interface.py"),
-)
-qri_mod = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(qri_mod)  # type: ignore
-sys.modules.setdefault("modules.universe_interface.quantum_reality_interface", qri_mod)
-
-QuantumRealityInterface = qri_mod.QuantumRealityInterface
-SpacetimeManipulation = qri_mod.SpacetimeManipulation
-MetricTensorModification = qri_mod.MetricTensorModification
-CurvatureProgramming = qri_mod.CurvatureProgramming
-CausalStructureModification = qri_mod.CausalStructureModification
-DimensionalAccess = qri_mod.DimensionalAccess
-SpacetimeTopologyChange = qri_mod.SpacetimeTopologyChange
-RealityProgram = qri_mod.RealityProgram
-PhysicalLawModification = qri_mod.PhysicalLawModification
-CosmicConstantAdjustment = qri_mod.CosmicConstantAdjustment
-ParticlePhysicsParameter = qri_mod.ParticlePhysicsParameter
-FieldEquationModification = qri_mod.FieldEquationModification
-RealityOptimizationObjective = qri_mod.RealityOptimizationObjective
 from modules.consciousness_physics.consciousness_field_theory import ConsciousnessFieldTheory
 
 

--- a/tests/test_recursive_consciousness.py
+++ b/tests/test_recursive_consciousness.py
@@ -11,64 +11,14 @@ from unittest.mock import Mock, AsyncMock, patch
 import sys
 import types
 import os
-try:
-    import numpy as np  # type: ignore
-except Exception:  # pragma: no cover - allow running without numpy
-    class _FakeNP:
-        pass
-
-    np = _FakeNP()
-    sys.modules.setdefault("numpy", np)
-try:
-    import networkx as nx  # type: ignore
-except Exception:  # pragma: no cover - allow running without networkx
-    class _FakeNX:
-        pass
-
-    nx = _FakeNX()
-    sys.modules.setdefault("networkx", nx)
-
-# Provide minimal stubs to satisfy heavy imports
-fake_sic = types.ModuleType("modules.recursive_consciousness.self_implementing_consciousness")
-class _StubSIC:
-    pass
-class _StubSpec:
-    pass
-class _StubSource:
-    pass
-fake_sic.SelfImplementingConsciousness = _StubSIC
-fake_sic.ConsciousnessComponentSpecification = _StubSpec
-fake_sic.ConsciousnessSourceCode = _StubSource
-sys.modules.setdefault("modules.recursive_consciousness.self_implementing_consciousness", fake_sic)
-
-fake_vm = types.ModuleType("modules.uor_meta_architecture.uor_meta_vm")
-class _StubVM:
-    pass
-fake_vm.UORMetaRealityVM = _StubVM
-sys.modules.setdefault("modules.uor_meta_architecture.uor_meta_vm", fake_vm)
-
-fake_rc = types.ModuleType("modules.recursive_consciousness")
-fake_rc.__path__ = [os.path.join(os.path.dirname(__file__), "..", "modules", "recursive_consciousness")]
-sys.modules.setdefault("modules.recursive_consciousness", fake_rc)
+import numpy as np
+import networkx as nx
 
 from modules.recursive_consciousness.consciousness_self_programming import (
     ConsciousnessSelfProgramming,
     ProgrammingObjective,
     ConsciousnessSelfModificationProgram,
 )
-
-fake_rc.SelfImplementingConsciousness = _StubSIC
-fake_rc.ConsciousnessSpecification = _StubSpec
-fake_rc.ConsciousnessSelfProgramming = ConsciousnessSelfProgramming
-fake_rc.ConsciousnessSelfModificationProgram = ConsciousnessSelfModificationProgram
-fake_rc.RecursiveArchitectureEvolution = object
-fake_rc.ConsciousnessBootstrapEngine = object
-fake_rc.UORRecursiveConsciousness = object
-fake_rc.InfiniteRecursiveSelfImprovement = object
-fake_rc.PrimeConsciousnessState = object
-fake_rc.EvolutionStrategy = object
-fake_rc.ImprovementDimension = object
-fake_rc.BootstrapPhase = object
 
 from modules.uor_meta_architecture.uor_meta_vm import UORMetaRealityVM
 from modules.recursive_consciousness import (

--- a/tests/test_unified_consciousness.py
+++ b/tests/test_unified_consciousness.py
@@ -6,81 +6,8 @@ import pytest
 import asyncio
 from datetime import datetime, timedelta
 from unittest.mock import Mock, AsyncMock, patch
-try:
-    import numpy as np
-except Exception:  # pragma: no cover - allow running without numpy
-    import math
-
-    class _FakeNP:
-        @staticmethod
-        def mean(values):
-            return sum(values) / len(values) if values else 0.0
-
-        @staticmethod
-        def clip(x, a, b):
-            return max(a, min(b, x))
-
-        @staticmethod
-        def isscalar(obj):
-            return isinstance(obj, (int, float))
-
-        ndarray = list
-
-    np = _FakeNP()
-    import sys
-    sys.modules.setdefault("numpy", np)
-
-import types
-
-# Stub modules required by the orchestrator to avoid heavy dependencies
-_stub_names = [
-    "consciousness.consciousness_core",
-    "consciousness.multi_level_awareness",
-    "consciousness.recursive_self_model",
-    "modules.strange_loops.loop_factory",
-    "modules.analogical_reasoning.analogy_engine",
-    "modules.creative_engine.creativity_core",
-    "modules.natural_language.consciousness_narrator",
-    "modules.philosophical_reasoning.consciousness_philosopher",
-    "modules.relational_intelligence.collaborative_creativity",
-    "modules.communication.emotion_articulator",
-]
-
-for name in _stub_names:
-    if name not in sys.modules:
-        module = types.ModuleType(name)
-        attr = name.split(".")[-1]
-        class_name = "".join(part.capitalize() for part in attr.split("_"))
-        setattr(module, class_name, object)
-        sys.modules[name] = module
-
-class _FakeGraph:
-    def __init__(self, nodes=0, edges=0):
-        self._nodes = nodes
-        self._edges = edges
-
-    def number_of_nodes(self):
-        return self._nodes
-
-    def number_of_edges(self):
-        return self._edges
-
-
-class _FakeNX:
-    Graph = _FakeGraph
-
-    def watts_strogatz_graph(self, n, k, p):
-        return _FakeGraph(n, n * k // 2)
-
-    def barabasi_albert_graph(self, n, m):
-        return _FakeGraph(n, n * m)
-
-    def complete_graph(self, n):
-        return _FakeGraph(n, n * (n - 1) // 2)
-
-
-sys.modules.setdefault("networkx", _FakeNX())
-
+import numpy as np
+import networkx as nx
 import importlib.util
 import os
 


### PR DESCRIPTION
## Summary
- remove custom numpy/networkx stand-ins from tests
- create helper module for any remaining stubbed classes
- import real modules in tests when available

## Testing
- `pytest -q` *(fails: FileNotFoundError in logging setup and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_b_683b64b70a18832097ec803bfe2c7c5a