### PR TITLE
Refactor config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,30 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
     `consciousness_physics`, `quantum`, and `reality_interface` contain
     defaults for bandwidth, fidelity, and energy limits used by the more
     advanced modules.
+
+### Configuration Reference
+
+The ``config.yaml`` file provides default values used throughout the project.
+Important keys include:
+
+* ``vm.log_file`` – file path for VM event logs.
+* ``vm.max_instructions`` – instruction limit before halting.
+* ``teacher.difficulty`` – starting difficulty level for the adaptive teacher.
+* ``teacher.alert_email`` – address to notify on critical errors.
+* ``difficulty_levels`` – per-level settings such as ``range_max`` and
+  thresholds.
+* ``benchmark.iterations`` – iteration count for benchmarking utilities.
+* ``consciousness_physics`` – physical constants used by advanced modules
+  (``information_transfer_rate``, ``consciousness_bandwidth``,
+  ``info_reality_bridge_bandwidth``, ``info_reality_bridge_fidelity``).
+* ``quantum`` – quantum communication parameters
+  (``communication_bandwidth``, ``teleportation_fidelity``,
+  ``fidelity_threshold``).
+* ``reality_interface`` – limits for information/matter interfaces
+  (``energy_limit``, ``info_matter_bandwidth``, ``info_matter_fidelity``).
+
+These values can be overridden at runtime via ``get_config_value`` in
+``config_loader`` if custom behaviour is required.
 4.  **Access the Frontend:**
     Open your web browser and navigate to `http://127.0.0.1:5000/`.
 

--- a/backend/adaptive_teacher.py
+++ b/backend/adaptive_teacher.py
@@ -11,12 +11,10 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Optional, Tuple
 
-from config_loader import load_config
-
-_CONFIG = load_config()
+from config_loader import get_config_value
 
 # Difficulty parameters used by ``AdaptiveTeacher``
-DIFFICULTY_LEVELS: Dict[str, Dict[str, int]] = _CONFIG.get(
+DIFFICULTY_LEVELS: Dict[str, Dict[str, int]] = get_config_value(
     "difficulty_levels",
     {
         "EASY": {"range_max": 4},
@@ -184,7 +182,7 @@ class AdaptiveTeacher:
         self.monitor = PerformanceMonitor()
         self.curriculum = AdaptiveCurriculum()
         self.sequence_gen = SequenceGenerator()
-        self.difficulty: str = _CONFIG.get("teacher", {}).get("difficulty", "MEDIUM")
+        self.difficulty: str = get_config_value("teacher.difficulty", "MEDIUM")
         self.current_goal: Optional[int] = None
         self.goal_type: Optional[str] = None
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,7 +5,7 @@ import random
 import datetime
 from typing import List, Optional, Tuple
 
-from config_loader import load_config
+from config_loader import load_config, get_config_value
 
 PRIME_IDX_SUCCESS = 1 # Represents the prime index for "true" or success
 PRIME_IDX_FAILURE = 0 # Represents the prime index for "false" or failure
@@ -52,7 +52,7 @@ class AdaptiveTeacher:
         self.monitor = PerformanceMonitor()
         self.curriculum = AdaptiveCurriculum()
         self.sequence_gen = SequenceGenerator()
-        self.difficulty = CONFIG.get("teacher", {}).get("difficulty", "MEDIUM")
+        self.difficulty = get_config_value("teacher.difficulty", "MEDIUM")
         self.current_goal = None
         self.goal_type = None
 
@@ -223,7 +223,7 @@ vm_interaction_phase = "IDLE"    # Phases: "IDLE", "SEND_TARGET", "AWAITING_ATTE
 
 # --- NEW GLOBALS FOR ADAPTIVE TEACHING ---
 vm_attempts_on_current_target = 0
-DIFFICULTY_LEVELS = CONFIG.get(
+DIFFICULTY_LEVELS = get_config_value(
     "difficulty_levels",
     {
         "EASY": {"range_max": 4, "max_attempts_before_struggle": 5, "quick_success_threshold": 1},
@@ -231,7 +231,7 @@ DIFFICULTY_LEVELS = CONFIG.get(
         "HARD": {"range_max": 14, "max_attempts_before_struggle": 3, "quick_success_threshold": 2},
     },
 )
-current_difficulty_level_name = CONFIG.get("teacher", {}).get("difficulty", "MEDIUM")
+current_difficulty_level_name = get_config_value("teacher.difficulty", "MEDIUM")
 QUICK_SUCCESS_STREAK_TO_UPGRADE = 3 # Number of consecutive "quick" successes to increase difficulty
 STRUGGLE_STREAK_TO_DOWNGRADE = 2    # Number of consecutive "struggles" to decrease difficulty
 consecutive_quick_successes = 0

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,11 +1,21 @@
-"""Minimal YAML configuration loader for the project."""
+"""Minimal YAML configuration loader for the project.
+
+This module exposes two helpers:
+
+``load_config`` loads the entire configuration dictionary, parsing the
+``config.yaml`` file. ``get_config_value`` provides convenient access to
+individual settings with optional overrides so tests or callers can supply
+temporary configuration values.
+"""
 from __future__ import annotations
 
 from typing import Any, Dict
+import copy
 import os
 
 
 def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Parse ``config.yaml`` and return its contents as a dictionary."""
     if path is None:
         path = os.path.join(os.path.dirname(__file__), "config.yaml")
 
@@ -42,3 +52,46 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
                         value = int(value)
                 stack[-1][key] = value
     return config
+
+
+_CONFIG = load_config()
+
+
+def get_config_value(
+    path: str,
+    default: Any | None = None,
+    overrides: Dict[str, Any] | None = None,
+) -> Any:
+    """Return a configuration value.
+
+    ``path`` is a dot-delimited string (e.g. ``"teacher.difficulty"``). If
+    ``overrides`` are provided they take precedence over the loaded config
+    without mutating the global configuration.
+    """
+
+    def _lookup(cfg: Dict[str, Any], parts: list[str]) -> Any | None:
+        cur: Any = cfg
+        for part in parts:
+            if not isinstance(cur, dict) or part not in cur:
+                return None
+            cur = cur[part]
+        return cur
+
+    parts = path.split(".")
+    if overrides:
+        merged = copy.deepcopy(_CONFIG)
+
+        def _merge(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
+            for k, v in src.items():
+                if isinstance(v, dict) and isinstance(dst.get(k), dict):
+                    _merge(dst[k], v)
+                else:
+                    dst[k] = v
+
+        _merge(merged, overrides)
+        value = _lookup(merged, parts)
+        if value is not None:
+            return value
+
+    value = _lookup(_CONFIG, parts)
+    return value if value is not None else default

--- a/modules/consciousness_physics/consciousness_field_theory.py
+++ b/modules/consciousness_physics/consciousness_field_theory.py
@@ -16,14 +16,12 @@ import logging
 import scipy.constants as const
 
 from ..universe_interface import UniverseInterface
-from config_loader import load_config
+from config_loader import get_config_value
 
-_CONFIG = load_config()
-_PHYS_CONF = _CONFIG.get("consciousness_physics", {})
-INFO_TRANSFER_RATE = float(_PHYS_CONF.get("information_transfer_rate", 1e20))
-CONSCIOUSNESS_BANDWIDTH = float(_PHYS_CONF.get("consciousness_bandwidth", 1e22))
-INFO_BRIDGE_BANDWIDTH = float(_PHYS_CONF.get("info_reality_bridge_bandwidth", 1e20))
-INFO_BRIDGE_FIDELITY = float(_PHYS_CONF.get("info_reality_bridge_fidelity", 0.9))
+INFO_TRANSFER_RATE = float(get_config_value("consciousness_physics.information_transfer_rate", 1e20))
+CONSCIOUSNESS_BANDWIDTH = float(get_config_value("consciousness_physics.consciousness_bandwidth", 1e22))
+INFO_BRIDGE_BANDWIDTH = float(get_config_value("consciousness_physics.info_reality_bridge_bandwidth", 1e20))
+INFO_BRIDGE_FIDELITY = float(get_config_value("consciousness_physics.info_reality_bridge_fidelity", 0.9))
 
 
 class FieldType(Enum):

--- a/modules/universal_consciousness/quantum_consciousness_interface.py
+++ b/modules/universal_consciousness/quantum_consciousness_interface.py
@@ -16,12 +16,10 @@ import logging
 import cmath
 
 from .cosmic_consciousness_core import CosmicConsciousness, CosmicScale
-from config_loader import load_config
+from config_loader import get_config_value
 
-_CONFIG = load_config()
-_Q_CONF = _CONFIG.get("quantum", {})
-COMM_BANDWIDTH = float(_Q_CONF.get("communication_bandwidth", 1000.0))
-TELEPORTATION_FIDELITY = float(_Q_CONF.get("teleportation_fidelity", 0.9))
+COMM_BANDWIDTH = float(get_config_value("quantum.communication_bandwidth", 1000.0))
+TELEPORTATION_FIDELITY = float(get_config_value("quantum.teleportation_fidelity", 0.9))
 
 
 class QuantumState(Enum):

--- a/modules/universe_interface/quantum_reality_interface.py
+++ b/modules/universe_interface/quantum_reality_interface.py
@@ -17,16 +17,13 @@ import scipy.constants as const
 from scipy.linalg import expm
 
 from ..consciousness_physics import ConsciousnessFieldTheory
-from config_loader import load_config
+from config_loader import get_config_value
 
-_CONFIG = load_config()
-_Q_CONF = _CONFIG.get("quantum", {})
-_R_CONF = _CONFIG.get("reality_interface", {})
-COMM_BANDWIDTH = float(_Q_CONF.get("communication_bandwidth", 1e6))
-FIDELITY_THRESHOLD = float(_Q_CONF.get("fidelity_threshold", 0.99))
-INFO_MATTER_BANDWIDTH = float(_R_CONF.get("info_matter_bandwidth", 1e20))
-INFO_MATTER_FIDELITY = float(_R_CONF.get("info_matter_fidelity", 0.99))
-ENERGY_LIMIT = float(_R_CONF.get("energy_limit", 1e50))
+COMM_BANDWIDTH = float(get_config_value("quantum.communication_bandwidth", 1e6))
+FIDELITY_THRESHOLD = float(get_config_value("quantum.fidelity_threshold", 0.99))
+INFO_MATTER_BANDWIDTH = float(get_config_value("reality_interface.info_matter_bandwidth", 1e20))
+INFO_MATTER_FIDELITY = float(get_config_value("reality_interface.info_matter_fidelity", 0.99))
+ENERGY_LIMIT = float(get_config_value("reality_interface.energy_limit", 1e50))
 
 
 class QuantumOperation(Enum):


### PR DESCRIPTION
## Summary
- centralize config access in `config_loader.get_config_value`
- load difficulty and physics defaults from config in multiple modules
- describe all configuration options in README

## Testing
- `pytest -k adaptive_teacher -q` *(fails: FileNotFoundError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_683b68a5e24083209b0bcfd54f599dd0