### PR TITLE
Implement stub versions of PrimeInstruction and transition manager

### DIFF
--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -4,14 +4,56 @@ These lightweight placeholders satisfy imports without
 relying on heavy or unfinished implementations.
 """
 
+from dataclasses import dataclass
+
+
+@dataclass
 class PrimeInstruction:
     """Minimal stand in for :class:`core.instruction_set.PrimeInstruction`."""
-    pass
+
+    opcode: int
+    operand: int = 0
+    encoding: tuple[int, int] = None
+
+    def __post_init__(self):
+        """Store a simple encoding of the instruction."""
+        self.encoding = (self.opcode, self.operand)
+
+    def decode(self) -> tuple[int, int]:
+        """Return the tracked opcode and operand."""
+        return self.encoding
+
+from typing import Any, List
+
+
+@dataclass
+class Transition:
+    """Simple transition representation."""
+
+    from_state: Any
+    to_state: Any
+    probability: float = 1.0
+
 
 class StateTransitionManager:
     """Simplified state transition manager for tests."""
-    def get_possible_transitions(self, state):
-        return []
 
-    def execute_transition(self, transition):
-        return None
+    def __init__(self, owner: Any = None):
+        self.owner = owner
+        self.transitions: List[Transition] = []
+
+    def add_transition(self, from_state: Any, to_state: Any,
+                       probability: float = 1.0) -> Transition:
+        transition = Transition(from_state, to_state, probability)
+        self.transitions.append(transition)
+        return transition
+
+    def get_possible_transitions(self, state: Any) -> List[Transition]:
+        """Return transitions originating from *state*."""
+        return [t for t in self.transitions if t.from_state == state]
+
+    def execute_transition(self, transition: Transition) -> Any:
+        """Execute a transition, recording it on the owner if possible."""
+        if self.owner and hasattr(self.owner, "state_transitions"):
+            self.owner.state_transitions.append(transition)
+        return transition.to_state


### PR DESCRIPTION
## Summary
- extend the test stubs used when core classes are missing
- provide minimal PrimeInstruction and StateTransitionManager behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' and others)*

------
https://chatgpt.com/codex/tasks/task_b_683b6b8771bc83208801268de52a7747