### PR TITLE
Refactor recursive consciousness stubs

### DIFF
--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -1,7 +1,12 @@
 """Test helper stubs for missing core classes.
 
-These lightweight placeholders satisfy imports without
-relying on heavy or unfinished implementations.
+These lightweight placeholders satisfy imports without relying on heavy or
+unfinished implementations.
+
+The module provides minimal substitutes for parts of ``core`` as well as
+meta-reality components required by the recursive consciousness tests.  The
+real versions will implement a fully featured meta-reality virtual machine and
+consciousness core.
 """
 
 from dataclasses import dataclass
@@ -57,3 +62,48 @@ class StateTransitionManager:
         if self.owner and hasattr(self.owner, "state_transitions"):
             self.owner.state_transitions.append(transition)
         return transition.to_state
+
+
+def install_recursive_consciousness_stubs():
+    """Install lightweight placeholders for recursive consciousness dependencies.
+
+    This sets up dummy modules for ``modules.uor_meta_architecture.uor_meta_vm``
+    and ``modules.meta_reality_consciousness.meta_reality_core``.  The real
+    packages provide the UOR meta-reality virtual machine and meta reality
+    consciousness core.  Until those complex subsystems are implemented these
+    stubs allow import statements to succeed in unit tests.
+    """
+
+    import types
+    import sys
+
+    sys.modules.setdefault(
+        "modules.uor_meta_architecture",
+        types.ModuleType("modules.uor_meta_architecture"),
+    )
+
+    vm_stub = types.ModuleType("modules.uor_meta_architecture.uor_meta_vm")
+    vm_stub.UORMetaRealityVM = object
+    vm_stub.MetaDimensionalInstruction = object
+    vm_stub.MetaOpCode = object
+    vm_stub.InfiniteOperand = object
+    sys.modules["modules.uor_meta_architecture.uor_meta_vm"] = vm_stub
+
+    sys.modules.setdefault(
+        "modules.meta_reality_consciousness",
+        types.ModuleType("modules.meta_reality_consciousness"),
+    )
+
+    meta_stub = types.ModuleType(
+        "modules.meta_reality_consciousness.meta_reality_core"
+    )
+
+    class _MRC:
+        def __init__(self, *a, **k):
+            pass
+
+    meta_stub.MetaRealityConsciousness = _MRC
+    sys.modules["modules.meta_reality_consciousness.meta_reality_core"] = meta_stub
+
+    return vm_stub, meta_stub
+

--- a/tests/test_recursive_consciousness.py
+++ b/tests/test_recursive_consciousness.py
@@ -13,6 +13,7 @@ import types
 import os
 import numpy as np
 import networkx as nx
+from tests.helpers import stubs
 
 from modules.recursive_consciousness.consciousness_self_programming import (
     ConsciousnessSelfProgramming,
@@ -103,19 +104,7 @@ class TestSelfImplementingConsciousness:
         )
         spec = importlib.util.spec_from_file_location("sic_real", path)
         sic_real = importlib.util.module_from_spec(spec)
-        # Provide missing attributes for heavy dependency
-        vm_stub = sys.modules.get("modules.uor_meta_architecture.uor_meta_vm")
-        if vm_stub is not None:
-            vm_stub.MetaDimensionalInstruction = object
-            vm_stub.MetaOpCode = object
-            vm_stub.InfiniteOperand = object
-
-        meta_stub = types.ModuleType("modules.meta_reality_consciousness.meta_reality_core")
-        class _MRC:
-            def __init__(self, *a, **k):
-                pass
-        meta_stub.MetaRealityConsciousness = _MRC
-        sys.modules.setdefault("modules.meta_reality_consciousness.meta_reality_core", meta_stub)
+        stubs.install_recursive_consciousness_stubs()
 
         spec.loader.exec_module(sic_real)
 
@@ -179,25 +168,7 @@ class TestSelfImplementingConsciousness:
         )
         runpy = __import__("runpy")
 
-        sys.modules.setdefault(
-            "modules.uor_meta_architecture", types.ModuleType("modules.uor_meta_architecture")
-        )
-        vm_stub = types.ModuleType("modules.uor_meta_architecture.uor_meta_vm")
-        vm_stub.UORMetaRealityVM = object
-        vm_stub.MetaDimensionalInstruction = object
-        vm_stub.MetaOpCode = object
-        vm_stub.InfiniteOperand = object
-        sys.modules["modules.uor_meta_architecture.uor_meta_vm"] = vm_stub
-
-        sys.modules.setdefault(
-            "modules.meta_reality_consciousness", types.ModuleType("modules.meta_reality_consciousness")
-        )
-        meta_stub = types.ModuleType("modules.meta_reality_consciousness.meta_reality_core")
-        class _MRC:
-            def __init__(self, *a, **k):
-                pass
-        meta_stub.MetaRealityConsciousness = _MRC
-        sys.modules["modules.meta_reality_consciousness.meta_reality_core"] = meta_stub
+        stubs.install_recursive_consciousness_stubs()
 
         mod_dict = runpy.run_path(path, run_name="sic_real")
         sic_real = types.ModuleType("sic_real")
@@ -243,18 +214,7 @@ class TestSelfImplementingConsciousness:
         spec = importlib.util.spec_from_file_location("sic_real", path)
         sic_real = importlib.util.module_from_spec(spec)
 
-        vm_stub = sys.modules.get("modules.uor_meta_architecture.uor_meta_vm")
-        if vm_stub is not None:
-            vm_stub.MetaDimensionalInstruction = object
-            vm_stub.MetaOpCode = object
-            vm_stub.InfiniteOperand = object
-
-        meta_stub = types.ModuleType("modules.meta_reality_consciousness.meta_reality_core")
-        class _MRC:
-            def __init__(self, *a, **k):
-                pass
-        meta_stub.MetaRealityConsciousness = _MRC
-        sys.modules.setdefault("modules.meta_reality_consciousness.meta_reality_core", meta_stub)
+        stubs.install_recursive_consciousness_stubs()
 
         spec.loader.exec_module(sic_real)
 

--- a/tests/test_self_implementation_validation.py
+++ b/tests/test_self_implementation_validation.py
@@ -2,6 +2,7 @@ import sys
 import os
 import types
 import importlib.util
+from tests.helpers import stubs
 
 # Stub heavy dependencies if missing
 try:
@@ -23,29 +24,7 @@ def load_sic():
     spec = importlib.util.spec_from_file_location("sic_real", path)
     sic_real = importlib.util.module_from_spec(spec)
 
-    sys.modules.setdefault(
-        "modules.uor_meta_architecture",
-        types.ModuleType("modules.uor_meta_architecture"),
-    )
-    vm_stub = types.ModuleType("modules.uor_meta_architecture.uor_meta_vm")
-    vm_stub.UORMetaRealityVM = object
-    vm_stub.MetaDimensionalInstruction = object
-    vm_stub.MetaOpCode = object
-    vm_stub.InfiniteOperand = object
-    sys.modules["modules.uor_meta_architecture.uor_meta_vm"] = vm_stub
-
-    sys.modules.setdefault(
-        "modules.meta_reality_consciousness",
-        types.ModuleType("modules.meta_reality_consciousness"),
-    )
-    meta_stub = types.ModuleType("modules.meta_reality_consciousness.meta_reality_core")
-
-    class _MRC:
-        def __init__(self, *a, **k):
-            pass
-
-    meta_stub.MetaRealityConsciousness = _MRC
-    sys.modules["modules.meta_reality_consciousness.meta_reality_core"] = meta_stub
+    stubs.install_recursive_consciousness_stubs()
 
     spec.loader.exec_module(sic_real)
     return sic_real


### PR DESCRIPTION
## Summary
- centralize stub modules for recursive consciousness in tests/helpers/stubs.py
- replace inline stub creation with `install_recursive_consciousness_stubs()`
- document placeholder modules for future implementation

## Testing
- `pytest -q` *(fails: FileNotFoundError: consciousness_chat.log, ModuleNotFoundError: numpy, networkx, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_683b6d3161548320add47e499e2f4e5e