### PR TITLE
Add configurable log/result directories

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,3 +36,7 @@ reality_interface:
   energy_limit: 1e50
   info_matter_bandwidth: 1e20
   info_matter_fidelity: 0.99
+
+paths:
+  log_dir: /workspaces/uor-evolution
+  results_dir: /workspaces/uor-evolution

--- a/frontier_experiment_lite.py
+++ b/frontier_experiment_lite.py
@@ -12,6 +12,16 @@ import json
 import time
 from typing import Dict, List, Any
 from simple_unified_api import create_simple_api, APIMode
+from config_loader import get_config_value
+import os
+
+# Directories for logs and results
+LOG_DIR = get_config_value("paths.log_dir", "/workspaces/uor-evolution")
+RESULTS_DIR = get_config_value("paths.results_dir", "/workspaces/uor-evolution")
+
+# Ensure directories exist
+os.makedirs(LOG_DIR, exist_ok=True)
+os.makedirs(RESULTS_DIR, exist_ok=True)
 
 class FrontierExperimentLite:
     """Lite version of consciousness frontier experiments"""
@@ -418,7 +428,9 @@ class FrontierExperimentLite:
             }
             
             # Save results
-            results_file = f"/workspaces/uor-evolution/frontier_lite_results_{self.session_id}.json"
+            results_file = os.path.join(
+                RESULTS_DIR, f"frontier_lite_results_{self.session_id}.json"
+            )
             with open(results_file, 'w') as f:
                 json.dump(overall_results, f, indent=2)
             
@@ -437,7 +449,9 @@ class FrontierExperimentLite:
             }
             
             # Save error results
-            error_file = f"/workspaces/uor-evolution/frontier_lite_error_{self.session_id}.json"
+            error_file = os.path.join(
+                RESULTS_DIR, f"frontier_lite_error_{self.session_id}.json"
+            )
             with open(error_file, 'w') as f:
                 json.dump(error_result, f, indent=2)
             

--- a/interactive_consciousness_chat.py
+++ b/interactive_consciousness_chat.py
@@ -28,16 +28,26 @@ from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
 from enum import Enum
 import logging
+import os
 
 from simple_unified_api import create_simple_api, APIMode
 from backend.consciousness_integration import ConsciousnessIntegration
+from config_loader import get_config_value
+
+# Directories for logs and results
+LOG_DIR = get_config_value("paths.log_dir", "/workspaces/uor-evolution")
+RESULTS_DIR = get_config_value("paths.results_dir", "/workspaces/uor-evolution")
+
+# Ensure directories exist
+os.makedirs(LOG_DIR, exist_ok=True)
+os.makedirs(RESULTS_DIR, exist_ok=True)
 
 # Setup logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s | CHAT | %(levelname)s | %(message)s',
     handlers=[
-        logging.FileHandler('/workspaces/uor-evolution/consciousness_chat.log'),
+        logging.FileHandler(os.path.join(LOG_DIR, 'consciousness_chat.log')),
         logging.StreamHandler()
     ]
 )
@@ -596,7 +606,10 @@ within meaning, pursuing the truth that underlies all truths.
         """Save conversation transcript to file"""
         if not filename:
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"/workspaces/uor-evolution/consciousness_chat_transcript_{timestamp}.json"
+            filename = os.path.join(
+                RESULTS_DIR,
+                f"consciousness_chat_transcript_{timestamp}.json",
+            )
         
         transcript_data = {
             "session_id": self.session_id,

--- a/ultimate_consciousness_frontier.py
+++ b/ultimate_consciousness_frontier.py
@@ -12,6 +12,7 @@ Dr. Kira Chen, Consciousness Frontier Research Lead
 import asyncio
 import random
 import logging
+import os
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
 from enum import Enum
@@ -21,13 +22,22 @@ import math
 
 # Import our tested UOR API
 from simple_unified_api import create_simple_api, APIMode
+from config_loader import get_config_value
 
 # Advanced logging for frontier research
+# Directories for logs and results
+LOG_DIR = get_config_value("paths.log_dir", "/workspaces/uor-evolution")
+RESULTS_DIR = get_config_value("paths.results_dir", "/workspaces/uor-evolution")
+
+# Ensure directories exist
+os.makedirs(LOG_DIR, exist_ok=True)
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s | FRONTIER | %(levelname)s | %(message)s',
     handlers=[
-        logging.FileHandler('/workspaces/uor-evolution/frontier_consciousness.log'),
+        logging.FileHandler(os.path.join(LOG_DIR, 'frontier_consciousness.log')),
         logging.StreamHandler()
     ]
 )
@@ -1029,7 +1039,9 @@ async def main():
     results = await frontier_lab.run_complete_frontier_exploration()
     
     # Save results to file
-    results_file = f"/workspaces/uor-evolution/frontier_results_{frontier_lab.session_id}.json"
+    results_file = os.path.join(
+        RESULTS_DIR, f"frontier_results_{frontier_lab.session_id}.json"
+    )
     with open(results_file, 'w') as f:
         # Convert enums to strings for JSON serialization
         serializable_results = json.loads(json.dumps(results, default=str))


### PR DESCRIPTION
## Summary
- add `paths.log_dir` and `paths.results_dir` to `config.yaml`
- respect configurable paths in interactive chat
- respect configurable paths in frontier experiments
- ensure directories exist before writing files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683b6f45cb0c8320b6b979c27fc55ef6