### PR TITLE
Add session directory configuration

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -39,8 +39,8 @@ The UOR Evolution repository implements a sophisticated consciousness and AI evo
 ```python
 from unified_api import create_api, APIMode
 
-# Create API instance
-api = create_api(APIMode.CONSCIOUSNESS)
+# Create API instance (session files saved to ./sessions)
+api = create_api(APIMode.CONSCIOUSNESS, session_dir="sessions")
 
 # Awaken consciousness
 result = api.awaken_consciousness()
@@ -156,8 +156,8 @@ api.orchestrate_consciousness()
 api.generate_insights()
 
 # Save/load sessions
-api.save_session("my_session.json")
-api.load_session("my_session.json")
+api.save_session("my_session.json")  # saved under "sessions/"
+api.load_session("my_session.json")  # loads from "sessions/"
 ```
 
 ### Response Format
@@ -205,10 +205,10 @@ full_results = full_system_demo()
 ### Session Management
 ```python
 # Save current session
-api.save_session("session_20241129.json")
+api.save_session("session_20241129.json")  # saved under "sessions/"
 
 # Load previous session
-api.load_session("session_20241129.json")
+api.load_session("session_20241129.json")  # loads from "sessions/"
 ```
 
 ### Pattern Recognition
@@ -237,7 +237,7 @@ from flask import Flask, jsonify
 from unified_api import create_api, APIMode
 
 app = Flask(__name__)
-uor_api = create_api(APIMode.CONSCIOUSNESS)
+uor_api = create_api(APIMode.CONSCIOUSNESS, session_dir="sessions")
 
 @app.route('/api/consciousness/awaken', methods=['POST'])
 def awaken():

--- a/UNIFIED_API_README.md
+++ b/UNIFIED_API_README.md
@@ -58,7 +58,7 @@ python demo_unified_api.py
 from unified_api import create_api, APIMode
 
 # Create API instance
-api = create_api(APIMode.CONSCIOUSNESS)
+api = create_api(APIMode.CONSCIOUSNESS, session_dir="sessions")
 
 # Awaken consciousness
 result = api.awaken_consciousness()
@@ -208,10 +208,10 @@ Save and restore system state:
 
 ```python
 # Save current session
-api.save_session("my_session.json")
+api.save_session("my_session.json")  # saved under "sessions/"
 
 # Load previous session
-api.load_session("my_session.json")
+api.load_session("my_session.json")  # loads from "sessions/"
 ```
 
 ## 🌐 Web Integration

--- a/simple_unified_api.py
+++ b/simple_unified_api.py
@@ -73,7 +73,7 @@ class SimpleUnifiedAPI:
     This version focuses on core functionality without complex dependencies.
     """
     
-    def __init__(self, mode: APIMode = APIMode.DEVELOPMENT):
+    def __init__(self, mode: APIMode = APIMode.DEVELOPMENT, session_dir: str = "."):
         """
         Initialize the simplified API.
         
@@ -83,6 +83,7 @@ class SimpleUnifiedAPI:
         self.mode = mode
         self.status = SystemStatus.DORMANT
         self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.session_dir = session_dir
         
         # State tracking
         self.system_state = SystemState()
@@ -624,6 +625,8 @@ class SimpleUnifiedAPI:
         try:
             if not filepath:
                 filepath = f"session_{self.session_id}.json"
+            if not os.path.isabs(filepath):
+                filepath = os.path.join(self.session_dir, filepath)
             
             session_data = {
                 'session_id': self.session_id,
@@ -651,9 +654,9 @@ class SimpleUnifiedAPI:
 
 # ==================== CONVENIENCE FUNCTIONS ====================
 
-def create_simple_api(mode: APIMode = APIMode.DEVELOPMENT) -> SimpleUnifiedAPI:
+def create_simple_api(mode: APIMode = APIMode.DEVELOPMENT, session_dir: str = ".") -> SimpleUnifiedAPI:
     """Create a new simplified unified API instance."""
-    return SimpleUnifiedAPI(mode)
+    return SimpleUnifiedAPI(mode, session_dir=session_dir)
 
 def quick_consciousness_demo() -> Dict[str, Any]:
     """Quick demonstration of consciousness capabilities."""

--- a/unified_api.py
+++ b/unified_api.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum
 import json
 import asyncio
+import os
 from pathlib import Path
 
 # Core imports
@@ -95,7 +96,7 @@ class UnifiedUORAPI:
     - Pattern analysis and insights
     """
     
-    def __init__(self, mode: APIMode = APIMode.DEVELOPMENT):
+    def __init__(self, mode: APIMode = APIMode.DEVELOPMENT, session_dir: str = "."):
         """
         Initialize the unified API.
         
@@ -105,6 +106,7 @@ class UnifiedUORAPI:
         self.mode = mode
         self.status = SystemStatus.DORMANT
         self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.session_dir = session_dir
         
         # Core components
         self.consciousness_core = ConsciousnessCore()
@@ -573,6 +575,8 @@ class UnifiedUORAPI:
         try:
             if not filepath:
                 filepath = f"session_{self.session_id}.json"
+            if not os.path.isabs(filepath):
+                filepath = os.path.join(self.session_dir, filepath)
             
             session_data = {
                 'session_id': self.session_id,
@@ -600,6 +604,8 @@ class UnifiedUORAPI:
     def load_session(self, filepath: str) -> APIResponse:
         """Load a previous session state."""
         try:
+            if not os.path.isabs(filepath):
+                filepath = os.path.join(self.session_dir, filepath)
             with open(filepath, 'r') as f:
                 session_data = json.load(f)
             
@@ -626,9 +632,9 @@ class UnifiedUORAPI:
 
 # ==================== CONVENIENCE FUNCTIONS ====================
 
-def create_api(mode: APIMode = APIMode.DEVELOPMENT) -> UnifiedUORAPI:
+def create_api(mode: APIMode = APIMode.DEVELOPMENT, session_dir: str = ".") -> UnifiedUORAPI:
     """Create a new unified API instance."""
-    return UnifiedUORAPI(mode)
+    return UnifiedUORAPI(mode, session_dir=session_dir)
 
 def quick_consciousness_demo() -> Dict[str, Any]:
     """Quick demonstration of consciousness capabilities."""


### PR DESCRIPTION
## Summary
- let `UnifiedUORAPI` and `SimpleUnifiedAPI` accept a `session_dir`
- join the configured directory with session filenames on save/load
- show the new argument in README examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683b71af3ab48320887ceb1f62f0d0bf