### PR TITLE
Enable configurable benchmark program

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ Important keys include:
 
 These values can be overridden at runtime via ``get_config_value`` in
 ``config_loader`` if custom behaviour is required.
+
+### Benchmarking PrimeVM
+
+Use ``benchmark.py`` to measure virtual machine performance. The default
+iteration count comes from ``benchmark.iterations`` in ``config.yaml``.
+Run a quick benchmark:
+
+```bash
+python benchmark.py
+```
+
+To execute a different program or adjust the iterations:
+
+```bash
+python benchmark.py --program mul --iterations 10000
+python benchmark.py --program my_program.json
+```
+
+``--program`` accepts the built-in names ``add``, ``sub`` and ``mul`` or a path
+to a JSON file containing a list of UOR chunks.
 4.  **Access the Frontend:**
     Open your web browser and navigate to `http://127.0.0.1:5000/`.
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,24 +1,79 @@
+"""Simple benchmarking utility for PrimeVM."""
+
+from __future__ import annotations
+
+import argparse
+import json
 import time
-from phase1_vm_enhancements import chunk_push, chunk_add, chunk_halt, vm_execute
+from pathlib import Path
+from typing import List
+
+from config_loader import get_config_value
+from phase1_vm_enhancements import (
+    chunk_add,
+    chunk_halt,
+    chunk_mul,
+    chunk_push,
+    chunk_sub,
+    vm_execute,
+)
 from enhanced_vm_interface import EnhancedVMInterface
 
-PROGRAM = [chunk_push(10), chunk_push(20), chunk_add(), chunk_halt()]
-ITERATIONS = 1000
 
-# Baseline direct execution
-start = time.time()
-for _ in range(ITERATIONS):
-    for _ in vm_execute(PROGRAM):
-        pass
-baseline = time.time() - start
+def _load_program(spec: str) -> List[int]:
+    """Return a UOR program from a name or file."""
+    builtins = {
+        "add": [chunk_push(10), chunk_push(20), chunk_add(), chunk_halt()],
+        "sub": [chunk_push(20), chunk_push(10), chunk_sub(), chunk_halt()],
+        "mul": [chunk_push(4), chunk_push(3), chunk_mul(), chunk_halt()],
+    }
+    if spec in builtins:
+        return builtins[spec]
 
-# Via interface
-iface = EnhancedVMInterface(PROGRAM)
-start = time.time()
-for _ in range(ITERATIONS):
-    iface.start()
-    iface.run_until_halt()
-interface_time = time.time() - start
+    path = Path(spec)
+    data = json.loads(path.read_text())
+    if not isinstance(data, list) or not all(isinstance(i, int) for i in data):
+        raise ValueError("Program file must contain a JSON array of integers")
+    return data
 
-print(f"Baseline time: {baseline:.4f}s")
-print(f"Interface time: {interface_time:.4f}s")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--program",
+        default="add",
+        help="Program name ('add', 'sub', 'mul') or path to JSON file",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=get_config_value("benchmark.iterations", 100),
+        help="Number of iterations to execute",
+    )
+
+    args = parser.parse_args()
+
+    program = _load_program(args.program)
+    iterations = args.iterations
+
+    # Baseline direct execution
+    start = time.time()
+    for _ in range(iterations):
+        for _ in vm_execute(program):
+            pass
+    baseline = time.time() - start
+
+    # Via interface
+    iface = EnhancedVMInterface(program)
+    start = time.time()
+    for _ in range(iterations):
+        iface.start()
+        iface.run_until_halt()
+    interface_time = time.time() - start
+
+    print(f"Baseline time: {baseline:.4f}s")
+    print(f"Interface time: {interface_time:.4f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow selecting a built‑in program or JSON file in `benchmark.py`
- add `--iterations` option using the value from `config.yaml` by default
- document benchmark usage in README

## Testing
- `pytest -q` *(fails: networkx missing and import errors)*

------
https://chatgpt.com/codex/tasks/task_b_683c1ab107108320be48ef1c7d57a0b0