### PR TITLE
Fix self-tests to exit on failure

### DIFF
--- a/phase1_vm_enhancements.py
+++ b/phase1_vm_enhancements.py
@@ -1106,10 +1106,10 @@ def _self_tests() -> Tuple[int,int]:
 
 if __name__=='__main__':
 
-    p,f=_self_tests()
-    print(f'\n[tests] {p} passed, {f} failed.') # Added a period for consistency.
+    p, f = _self_tests()
+    print(f'\n[tests] {p} passed, {f} failed.')  # Added a period for consistency.
     if f:
-        pass 
+        raise SystemExit(1)
 
     print("\n--- Demo ---")
     _extend_primes_to(ord('🎉') + 10) 


### PR DESCRIPTION
## Summary
- exit immediately when self-tests fail

## Testing
- `pytest -q` *(fails: AttributeError: module 'networkx'... 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683c24a5bf2c8320a77f479e249399d7