### PR TITLE
Make UOR generator output path configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for taking the time to contribute! This project welcomes bug reports, 
    ```
 4. Generate the UOR program:
    ```bash
-   python generate_goal_seeker_uor.py
+   python generate_goal_seeker_uor.py [--output <path>]
    ```
 5. Run the backend server:
    ```bash

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
 
 ```
 ├── backend/
-│ ├── uor_programs/
-│ │ └── goal_seeker_demo.uor.txt # Generated UOR program
 │ ├── __init__.py
 │ ├── app.py # Flask backend, "Teacher" logic
 │ └── adaptive_teacher.py # Adaptive teaching classes
+├── <results_dir>/uor_programs/
+│ └── goal_seeker_demo.uor.txt # Generated UOR program
 ├── frontend/
 │ ├── css/
 │ │ └── style.css # Styles for the UI
@@ -143,9 +143,10 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
 1.  **Generate the UOR Program (if not present or if modified):**
     Open a terminal in the project root directory and run:
     ```bash
-    python generate_goal_seeker_uor.py
+    python generate_goal_seeker_uor.py [--output <path>]
     ```
-    This will create/update `backend/uor_programs/goal_seeker_demo.uor.txt`.
+    This will create/update `goal_seeker_demo.uor.txt` under the configured
+    `paths.results_dir` (default `<results_dir>/uor_programs/`).
 
 2.  **Run the Flask Web Application (Teacher & VM Backend):**
     In the same terminal, run:

--- a/UNIFIED_API_README.md
+++ b/UNIFIED_API_README.md
@@ -315,7 +315,8 @@ def create_consciousness_network():
    ```
 
 2. **VM Initialization Fails**
-   - Check that UOR program files exist in `backend/uor_programs/`
+   - Check that UOR program files exist under the configured
+     `paths.results_dir` (default `<results_dir>/uor_programs/`)
    - Ensure `goal_seeker_demo.uor.txt` is present
 
 3. **Consciousness Not Awakening**

--- a/generate_goal_seeker_uor.py
+++ b/generate_goal_seeker_uor.py
@@ -2,6 +2,9 @@ import sys
 import os
 from dataclasses import dataclass, field
 from typing import List
+import argparse
+
+from config_loader import get_config_value
 
 project_root = os.path.dirname(os.path.abspath(__file__))
 if project_root not in sys.path:
@@ -814,13 +817,39 @@ def generate_goal_seeker_program(return_debug: bool = False):
     return (program_uor, metadata) if return_debug else program_uor
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Generate the goal-seeker UOR program"
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Output file or directory. If a directory is supplied, the file "
+            "will be named 'goal_seeker_demo.uor.txt'. Defaults to "
+            "paths.results_dir/uor_programs."
+        ),
+    )
+    args = parser.parse_args()
+
     uor_chunks = generate_goal_seeker_program()
-    
-    output_dir = os.path.join(project_root, "backend", "uor_programs")
+
+    if args.output:
+        potential_dir = args.output
+        if os.path.isdir(potential_dir) or potential_dir.endswith(os.sep):
+            output_dir = potential_dir.rstrip(os.sep)
+            output_filename = os.path.join(output_dir, "goal_seeker_demo.uor.txt")
+        else:
+            output_dir = os.path.dirname(potential_dir)
+            output_filename = potential_dir
+    else:
+        base_dir = get_config_value("paths.results_dir", project_root)
+        output_dir = os.path.join(base_dir, "uor_programs")
+        output_filename = os.path.join(output_dir, "goal_seeker_demo.uor.txt")
+
     os.makedirs(output_dir, exist_ok=True)
-    output_filename = os.path.join(output_dir, "goal_seeker_demo.uor.txt")
 
     with open(output_filename, "w") as f:
         for chunk_val in uor_chunks:
             f.write(str(chunk_val) + "\n")
-    print(f"Generated UOR program ({len(uor_chunks)} instructions) at: {output_filename}")
+    print(
+        f"Generated UOR program ({len(uor_chunks)} instructions) at: {output_filename}"
+    )


### PR DESCRIPTION
## Summary
- allow `generate_goal_seeker_uor.py` to take an optional `--output` argument
- default the goal seeker program location to `paths.results_dir/uor_programs`
- document the new argument in README and CONTRIBUTING
- update Unified API docs for the new default location

## Testing
- `pytest tests/test_goal_seeker_placeholders.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683c289108bc8320ada7e2a33fd6db31