### PR TITLE
Make log path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
         *   VM output log.
         *   VM status (IP, Halted, Error, Target, Difficulty).
     *   Retro "hacker" themed UI for a more engaging experience.
-*   **Backend Logging:** Detailed logging of VM initialization, steps, inputs, and state changes in `log.txt`.
+*   **Backend Logging:** Detailed logging of VM initialization, steps, inputs, and state changes. The log file location is configurable via `vm.log_file` in `config.yaml` (or the `LOG_FILE_PATH` environment variable).
 
 ## Future Improvements
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -59,7 +59,13 @@ from phase1_vm_enhancements import (
 )
 
 # --- Log File Setup ---
-LOG_FILE_PATH = os.path.join(PROJECT_ROOT, "log.txt")
+# Log file path can be configured via the ``LOG_FILE_PATH`` environment
+# variable or ``vm.log_file`` in ``config.yaml``. A relative path will be
+# resolved against ``PROJECT_ROOT``.
+_cfg_log_file = os.environ.get("LOG_FILE_PATH") or get_config_value("vm.log_file", "log.txt")
+LOG_FILE_PATH = _cfg_log_file
+if not os.path.isabs(LOG_FILE_PATH):
+    LOG_FILE_PATH = os.path.join(PROJECT_ROOT, LOG_FILE_PATH)
 
 def append_to_log(message: str):
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]


### PR DESCRIPTION
## Summary
- read log file path from `config.yaml` or `LOG_FILE_PATH` environment variable
- document configurable backend log path in README

## Testing
- `pytest tests/test_error_logging.py::TestErrorLogging::test_condition_logs_on_failure -q`
- `pytest test_suite.py::TestVMInstructions::test_sub -q`


------
https://chatgpt.com/codex/tasks/task_b_683c41c85314832093f6992414e99521