### PR TITLE
Make UOR program configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
 │ └── adaptive_teacher.py # Adaptive teaching classes
 ├── <results_dir>/uor_programs/
 │ └── goal_seeker_demo.uor.txt # Generated UOR program
+#                       (name set by `paths.default_uor_program`)
 ├── frontend/
 │ ├── css/
 │ │ └── style.css # Styles for the UI
@@ -145,8 +146,8 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
     ```bash
     python generate_goal_seeker_uor.py [--output <path>]
     ```
-    This will create/update `goal_seeker_demo.uor.txt` under the configured
-    `paths.results_dir` (default `<results_dir>/uor_programs/`).
+    This will create/update the file specified by `paths.default_uor_program`
+    under `paths.results_dir` (default `<results_dir>/uor_programs/>`).
 
 2.  **Run the Flask Web Application (Teacher & VM Backend):**
     In the same terminal, run:

--- a/UNIFIED_API_README.md
+++ b/UNIFIED_API_README.md
@@ -317,7 +317,7 @@ def create_consciousness_network():
 2. **VM Initialization Fails**
    - Check that UOR program files exist under the configured
      `paths.results_dir` (default `<results_dir>/uor_programs/`)
-   - Ensure `goal_seeker_demo.uor.txt` is present
+   - Ensure the file specified by `paths.default_uor_program` is present
 
 3. **Consciousness Not Awakening**
    - Verify consciousness core initialization

--- a/backend/app.py
+++ b/backend/app.py
@@ -276,8 +276,17 @@ consecutive_quick_successes = 0
 consecutive_struggles = 0
 
 # --- Helper to load UOR program ---
-def load_uor_program(filename="goal_seeker_demo.uor.txt"):
+def load_uor_program(filename: str | None = None) -> bool:
+    """Load a UOR program into ``current_vm_program``.
+
+    If ``filename`` is ``None`` the value from
+    ``paths.default_uor_program`` in the configuration will be used.
+    """
     global current_vm_program
+    if filename is None:
+        filename = get_config_value(
+            "paths.default_uor_program", "goal_seeker_demo.uor.txt"
+        )
     program_path = os.path.join(PROJECT_ROOT, "backend", "uor_programs", filename)
     current_vm_program = []
     try:
@@ -436,8 +445,11 @@ def initialize_vm():
            current_target_value_idx, vm_interaction_phase
 
     append_to_log("--- VM INITIALIZATION START (Goal-Seeker) ---")
-    # Load the NEW goal_seeker UOR program
-    if not load_uor_program("goal_seeker_demo.uor.txt"): 
+    # Load the goal_seeker UOR program from configuration
+    program_filename = get_config_value(
+        "paths.default_uor_program", "goal_seeker_demo.uor.txt"
+    )
+    if not load_uor_program(program_filename):
         vm_error = "Failed to load UOR program."
         append_to_log(f"ERROR: {vm_error}")
         append_to_log("--- VM INITIALIZATION FAILED (Goal-Seeker) ---")
@@ -503,11 +515,13 @@ def initialize_vm():
     # Update the global current_vm_stack so get_vm_state_dict() is accurate even before the first step
     current_vm_stack = list(stack_for_this_vm_run) 
     
-    vm_generator = vm_execute(list(current_vm_program), list(stack_for_this_vm_run)) # Use the locally defined stack
-    
+    vm_generator = vm_execute(list(current_vm_program), list(stack_for_this_vm_run))  # Use the locally defined stack
+
     # Log messages updated for new stack convention
-    loaded_program_filename = "goal_seeker_demo.uor.txt" # Make sure this filename is correct for the new UOR
-    append_to_log(f"VM Initialized (Ambitious). Program: {loaded_program_filename}. Initial Target (for Addr0 PUSH): {current_target_value_idx}. Phase: {vm_interaction_phase}")
+    loaded_program_filename = program_filename  # record which file was loaded
+    append_to_log(
+        f"VM Initialized (Ambitious). Program: {loaded_program_filename}. Initial Target (for Addr0 PUSH): {current_target_value_idx}. Phase: {vm_interaction_phase}"
+    )
     append_to_log(f"Initial Stack (contents: [last_pokéd_addr0_val, sfc, last_slot_addr_val, last_instr_type_val]): {current_vm_stack}. Initial IP: {current_vm_ip}.")
     append_to_log(f"VM waiting for input (at init end): {vm_is_waiting_for_input}")
     append_to_log("--- VM INITIALIZATION COMPLETE (Ambitious Goal-Seeker) ---")

--- a/config.yaml
+++ b/config.yaml
@@ -47,3 +47,4 @@ reality_interface:
 paths:
   log_dir: /workspaces/uor-evolution
   results_dir: /workspaces/uor-evolution
+  default_uor_program: goal_seeker_demo.uor.txt

--- a/generate_goal_seeker_uor.py
+++ b/generate_goal_seeker_uor.py
@@ -820,11 +820,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Generate the goal-seeker UOR program"
     )
+    default_name = get_config_value("paths.default_uor_program", "goal_seeker_demo.uor.txt")
     parser.add_argument(
         "--output",
         help=(
             "Output file or directory. If a directory is supplied, the file "
-            "will be named 'goal_seeker_demo.uor.txt'. Defaults to "
+            f"will be named '{default_name}'. Defaults to "
             "paths.results_dir/uor_programs."
         ),
     )
@@ -836,14 +837,14 @@ if __name__ == '__main__':
         potential_dir = args.output
         if os.path.isdir(potential_dir) or potential_dir.endswith(os.sep):
             output_dir = potential_dir.rstrip(os.sep)
-            output_filename = os.path.join(output_dir, "goal_seeker_demo.uor.txt")
+            output_filename = os.path.join(output_dir, default_name)
         else:
             output_dir = os.path.dirname(potential_dir)
             output_filename = potential_dir
     else:
         base_dir = get_config_value("paths.results_dir", project_root)
         output_dir = os.path.join(base_dir, "uor_programs")
-        output_filename = os.path.join(output_dir, "goal_seeker_demo.uor.txt")
+        output_filename = os.path.join(output_dir, default_name)
 
     os.makedirs(output_dir, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- use `paths.default_uor_program` config key instead of hardcoded filename
- update VM initialization to read program filename from config
- document new config setting in README files
- adjust `generate_goal_seeker_uor.py` CLI help

## Testing
- `pytest -q` *(fails: module 'networkx' has no attribute 'Graph' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_683c430a6570832086970d769f03a885