### PR TITLE
Expose step cycle instructions limit via config

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -246,7 +246,7 @@ current_vm_output_log = []
 vm_halted = False
 vm_error = None
 vm_generator = None
-MAX_INSTRUCTIONS_PER_STEP_CYCLE = 1
+MAX_INSTRUCTIONS_PER_STEP_CYCLE = int(get_config_value("vm.max_instructions_per_cycle", 1))
 vm_is_waiting_for_input = False
 
 # --- NEW GLOBALS FOR GOAL-SEEKING DEMO ---

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ debug: false
 vm:
   log_file: vm_events.log
   max_instructions: 1000
+  max_instructions_per_cycle: 1
 teacher:
   difficulty: MEDIUM
   alert_email: operator@example.com


### PR DESCRIPTION
## Summary
- make VM step cycle max instructions configurable
- document `vm.max_instructions_per_cycle` in `config.yaml`

## Testing
- `pytest -q` *(fails: networkx missing Graph attribute and other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_683c807526e883208022f908573fb0b6