### PR TITLE
Parameterize UOR program initial push

### DIFF
--- a/generate_goal_seeker_uor.py
+++ b/generate_goal_seeker_uor.py
@@ -183,7 +183,8 @@ def validate_uor_program(program: List[int],
     if unresolved:
         raise ValueError(f"Unresolved placeholders at {unresolved}")
 
-def generate_goal_seeker_program(return_debug: bool = False):
+def generate_goal_seeker_program(initial_prime_idx: int,
+                                 return_debug: bool = False):
     _extend_primes_to(max(35, STUCK_SIGNAL_PRINT_VALUE_IDX, MAX_FAILURES_BEFORE_STUCK_IDX, RANDOM_MAX_EXCLUSIVE_IDX_FOR_OFFSET, ATTEMPT_MODULUS_IDX, MODIFICATION_SLOT_0_ADDR_IDX, MODIFICATION_SLOT_1_ADDR_IDX, UOR_DECISION_BUILD_NOP_IDX) + 10) # Added new constants and a bit more buffer
 
     program_uor = []
@@ -205,7 +206,8 @@ def generate_goal_seeker_program(return_debug: bool = False):
     failure_streak = 0
 
     # ADDR 0: PUSH current_value_to_work_with (This instruction is self-modified by POKE_CHUNK, based on success/failure of PRINTING the target)
-    program_uor.append(chunk_push(FEEDBACK_FAILURE_IDX)) # Initial dummy value, will be overwritten by app.py
+    assert initial_prime_idx != 0, "initial_prime_idx cannot be zero"
+    program_uor.append(chunk_push(initial_prime_idx))  # Initial dummy value, will be overwritten by app.py
     labels["MAIN_EXECUTION_LOOP_START"] = 0
     # Stack: [current_val, last_pokéd_val_for_addr0, sfc, last_slot, last_instr_type]
 
@@ -831,7 +833,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    uor_chunks = generate_goal_seeker_program()
+    uor_chunks = generate_goal_seeker_program(initial_prime_idx=FEEDBACK_SUCCESS_IDX)
 
     if args.output:
         potential_dir = args.output

--- a/tests/test_goal_seeker_placeholders.py
+++ b/tests/test_goal_seeker_placeholders.py
@@ -1,10 +1,13 @@
 import pytest
-from generate_goal_seeker_uor import generate_goal_seeker_program
+from generate_goal_seeker_uor import (
+    generate_goal_seeker_program,
+    FEEDBACK_SUCCESS_IDX,
+)
 from phase1_vm_enhancements import chunk_push, parse_opcode_and_operand, OP_PUSH
 
 
 def test_placeholder_resolution():
-    program, meta = generate_goal_seeker_program(return_debug=True)
+    program, meta = generate_goal_seeker_program(initial_prime_idx=FEEDBACK_SUCCESS_IDX, return_debug=True)
 
     labels = meta['labels']
     jump_placeholders = meta['jump_placeholders']


### PR DESCRIPTION
## Summary
- allow generating the goal seeker UOR program with a configurable first PUSH value
- update test to use the new parameter

## Testing
- `pytest -q tests/test_goal_seeker_placeholders.py`

------
https://chatgpt.com/codex/tasks/task_b_683c841635ec83208589cf46f39429e9