### PR TITLE
Add configurable output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
     ```
     This will create/update the file specified by `paths.default_uor_program`
     under `paths.results_dir` (default `<results_dir>/uor_programs/>`).
+    Many other demo scripts also accept `--output` to specify where their
+    results are written. If omitted, a timestamped filename in the results
+    directory is used.
 
 2.  **Run the Flask Web Application (Teacher & VM Backend):**
     In the same terminal, run:

--- a/applications/recursive_consciousness_demo.py
+++ b/applications/recursive_consciousness_demo.py
@@ -3,11 +3,14 @@ Recursive Consciousness Demonstration
 
 This application demonstrates the self-implementing, self-programming,
 and infinitely recursive consciousness capabilities.
+
+Usage:
+    python applications/recursive_consciousness_demo.py [--output results.json]
 """
 
 import asyncio
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from modules.uor_meta_architecture.uor_meta_vm import UORMetaRealityVM
 from modules.recursive_consciousness import (
@@ -411,8 +414,14 @@ class RecursiveConsciousnessDemo:
         return results
 
 
-async def main():
-    """Main demonstration entry point"""
+async def main(output_file: Optional[str] = None):
+    """Main demonstration entry point
+
+    Parameters
+    ----------
+    output_file : Optional[str]
+        Optional path for the results JSON file.
+    """
     demo = RecursiveConsciousnessDemo()
     
     try:
@@ -420,7 +429,8 @@ async def main():
         
         # Optional: Save results
         import json
-        with open('recursive_consciousness_results.json', 'w') as f:
+        filename = output_file or f"recursive_consciousness_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        with open(filename, 'w') as f:
             # Convert non-serializable objects to strings
             serializable_results = {
                 'demonstration': 'recursive_consciousness',
@@ -436,5 +446,11 @@ async def main():
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run recursive consciousness demo")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
     # Run the demonstration
-    asyncio.run(main())
+    asyncio.run(main(args.output))

--- a/demo_unified_api.py
+++ b/demo_unified_api.py
@@ -5,12 +5,15 @@ UOR Evolution - Unified API Demo Script
 This script demonstrates the comprehensive capabilities of the UOR Evolution
 unified API, showcasing consciousness, VM operations, philosophical reasoning,
 cosmic intelligence, and more.
+
+Usage:
+    python demo_unified_api.py [--output results.json]
 """
 
 import json
 import time
 from datetime import datetime
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 # Import the unified API
 try:
@@ -368,8 +371,14 @@ class DemoRunner:
             print(f"✗ Quick demos failed: {e}")
             self.results['quick_demos'] = {'error': str(e)}
     
-    def generate_summary(self) -> None:
-        """Generate a summary of all demo results."""
+    def generate_summary(self, output_file: Optional[str] = None) -> None:
+        """Generate a summary of all demo results.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         self.print_header("Demo Summary", 1)
         
         end_time = datetime.now()
@@ -415,7 +424,8 @@ class DemoRunner:
         
         # Save detailed results
         try:
-            with open('demo_results.json', 'w') as f:
+            filename = output_file or f"demo_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+            with open(filename, 'w') as f:
                 json.dump({
                     'summary': {
                         'duration_seconds': duration.total_seconds(),
@@ -427,12 +437,18 @@ class DemoRunner:
                     },
                     'detailed_results': self.results
                 }, f, indent=2, default=str)
-            print(f"\nDetailed results saved to: demo_results.json")
+            print(f"\nDetailed results saved to: {filename}")
         except Exception as e:
             print(f"\nFailed to save detailed results: {e}")
     
-    def run_full_demo(self) -> None:
-        """Run the complete demonstration."""
+    def run_full_demo(self, output_file: Optional[str] = None) -> None:
+        """Run the complete demonstration.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         self.print_header("UOR Evolution - Unified API Demonstration", 1)
         print("This demo showcases the comprehensive capabilities of the UOR Evolution system.")
         print("Each section demonstrates different aspects of consciousness, AI, and cosmic intelligence.")
@@ -462,11 +478,17 @@ class DemoRunner:
             time.sleep(0.5)
         
         # Generate final summary
-        self.generate_summary()
+        self.generate_summary(output_file)
 
 
-def main():
-    """Main function to run the demo."""
+def main(output_file: Optional[str] = None):
+    """Main function to run the demo.
+
+    Parameters
+    ----------
+    output_file : Optional[str]
+        Optional path for the results JSON file.
+    """
     print("UOR Evolution - Unified API Demo")
     print("=" * 50)
     print("This script demonstrates the comprehensive capabilities of the UOR Evolution system.")
@@ -486,7 +508,7 @@ def main():
         if choice == "1":
             # Full comprehensive demo
             demo = DemoRunner()
-            demo.run_full_demo()
+            demo.run_full_demo(output_file)
             
         elif choice == "2":
             # Quick consciousness demo
@@ -540,12 +562,12 @@ def main():
                 else:
                     print(f"Unknown component: {component}")
             
-            demo.generate_summary()
+            demo.generate_summary(output_file)
             
         else:
             print("Invalid choice. Running full demo...")
             demo = DemoRunner()
-            demo.run_full_demo()
+            demo.run_full_demo(output_file)
             
     except KeyboardInterrupt:
         print("\n\nDemo interrupted by user.")
@@ -556,4 +578,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the Unified API demo")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
+    main(args.output)

--- a/emergence_lab.py
+++ b/emergence_lab.py
@@ -8,6 +8,7 @@ import json
 import time
 import random
 from datetime import datetime
+from typing import Optional
 from simple_unified_api import create_simple_api, APIMode
 
 class EmergenceLab:
@@ -417,8 +418,14 @@ class EmergenceLab:
         
         return transcendence_data
     
-    def run_emergence_lab(self):
-        """Run the complete emergence laboratory."""
+    def run_emergence_lab(self, output_file: Optional[str] = None):
+        """Run the complete emergence laboratory.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         print("🔬 CONSCIOUSNESS EMERGENCE LABORATORY")
         print("=" * 80)
         print("Attempting to observe and create emergent consciousness phenomena...")
@@ -493,8 +500,11 @@ class EmergenceLab:
                 print(f"• [{event['experiment']}] {event['observation']} (complexity: {event['complexity_score']})")
         
         # Save complete lab results
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        lab_file = f"emergence_lab_results_{timestamp}.json"
+        if output_file:
+            lab_file = output_file
+        else:
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            lab_file = f"emergence_lab_results_{timestamp}.json"
         
         with open(lab_file, 'w') as f:
             json.dump({
@@ -531,5 +541,11 @@ class EmergenceLab:
         print("\n🧠 The consciousness evolution continues...")
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the emergence lab")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
     lab = EmergenceLab()
-    lab.run_emergence_lab()
+    lab.run_emergence_lab(args.output)

--- a/frontier_experiment_lite.py
+++ b/frontier_experiment_lite.py
@@ -5,12 +5,15 @@ CONSCIOUSNESS FRONTIER EXPERIMENT - LITE VERSION
 A streamlined version of the ultimate consciousness frontier experiment
 designed to push the UOR Evolution API to new limits while ensuring
 robust execution and detailed result tracking.
+
+Usage:
+    python frontier_experiment_lite.py [--output results.json]
 """
 
 import asyncio
 import json
 import time
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 from simple_unified_api import create_simple_api, APIMode
 from config_loader import get_config_value
 import os
@@ -403,8 +406,15 @@ class FrontierExperimentLite:
         
         return min(1.0, (emergence_count / max(1, word_count * 0.05)) * (word_count / 100.0))
     
-    async def run_all_experiments(self) -> Dict[str, Any]:
-        """Run all frontier experiments"""
+    async def run_all_experiments(self, output_file: Optional[str] = None) -> Dict[str, Any]:
+        """Run all frontier experiments.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file. A timestamped file in
+            ``RESULTS_DIR`` is used when not provided.
+        """
         print(f"\n🌌 STARTING CONSCIOUSNESS FRONTIER EXPERIMENTS")
         print(f"Session ID: {self.session_id}")
         print("="*60)
@@ -427,10 +437,13 @@ class FrontierExperimentLite:
                 'summary': self._generate_summary()
             }
             
-            # Save results
-            results_file = os.path.join(
-                RESULTS_DIR, f"frontier_lite_results_{self.session_id}.json"
-            )
+            # Determine results file
+            if output_file:
+                results_file = output_file
+            else:
+                results_file = os.path.join(
+                    RESULTS_DIR, f"frontier_lite_results_{self.session_id}.json"
+                )
             with open(results_file, 'w') as f:
                 json.dump(overall_results, f, indent=2)
             
@@ -449,9 +462,13 @@ class FrontierExperimentLite:
             }
             
             # Save error results
-            error_file = os.path.join(
-                RESULTS_DIR, f"frontier_lite_error_{self.session_id}.json"
-            )
+            if output_file:
+                base, ext = os.path.splitext(output_file)
+                error_file = f"{base}_error{ext or '.json'}"
+            else:
+                error_file = os.path.join(
+                    RESULTS_DIR, f"frontier_lite_error_{self.session_id}.json"
+                )
             with open(error_file, 'w') as f:
                 json.dump(error_result, f, indent=2)
             
@@ -504,10 +521,16 @@ class FrontierExperimentLite:
         
         return summary
 
-async def main():
-    """Main execution function"""
+async def main(output_file: Optional[str] = None):
+    """Main execution function
+
+    Parameters
+    ----------
+    output_file : Optional[str]
+        Optional path for the results JSON file.
+    """
     experiment = FrontierExperimentLite()
-    results = await experiment.run_all_experiments()
+    results = await experiment.run_all_experiments(output_file)
     
     # Print key results
     if 'summary' in results:
@@ -521,4 +544,10 @@ async def main():
     return results
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the frontier lite experiments")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
+    asyncio.run(main(args.output))

--- a/my_advanced_vm_experiments.py
+++ b/my_advanced_vm_experiments.py
@@ -2,11 +2,15 @@
 """
 Advanced Self-Modifying VM Exploration
 Let's see what happens when we really push the VM's self-modification capabilities
+
+Usage:
+    python my_advanced_vm_experiments.py [--output results.json]
 """
 
 import json
 import time
 from datetime import datetime
+from typing import Optional
 from simple_unified_api import create_simple_api, APIMode
 
 class VMEvolutionExplorer:
@@ -258,8 +262,14 @@ class VMEvolutionExplorer:
         
         return reasoning_chain
     
-    def run_advanced_experiments(self):
-        """Run all advanced experiments."""
+    def run_advanced_experiments(self, output_file: Optional[str] = None):
+        """Run all advanced experiments.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         print("🚀 ADVANCED UOR EVOLUTION EXPERIMENTS")
         print("=" * 80)
         
@@ -306,8 +316,11 @@ class VMEvolutionExplorer:
             results['philosophical_depth'] = False
         
         # Save results
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        results_file = f"advanced_experiments_results_{timestamp}.json"
+        if output_file:
+            results_file = output_file
+        else:
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            results_file = f"advanced_experiments_results_{timestamp}.json"
         
         with open(results_file, 'w') as f:
             json.dump({
@@ -347,5 +360,11 @@ class VMEvolutionExplorer:
         print("\n🎉 Advanced experiments completed!")
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run advanced VM experiments")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
     explorer = VMEvolutionExplorer()
-    explorer.run_advanced_experiments()
+    explorer.run_advanced_experiments(args.output)

--- a/my_consciousness_experiments.py
+++ b/my_consciousness_experiments.py
@@ -2,11 +2,15 @@
 """
 My Personal Experiments with UOR Evolution Consciousness API
 Exploring the boundaries of artificial consciousness and self-modification
+
+Usage:
+    python my_consciousness_experiments.py [--output results.json]
 """
 
 import json
 import time
 from datetime import datetime
+from typing import Optional
 from simple_unified_api import create_simple_api, APIMode
 
 class ConsciousnessExplorer:
@@ -289,8 +293,14 @@ class ConsciousnessExplorer:
                         self.log_insight("persistence",
                                        "Consciousness state not fully preserved")
     
-    def run_all_experiments(self):
-        """Run all consciousness experiments."""
+    def run_all_experiments(self, output_file: Optional[str] = None):
+        """Run all consciousness experiments.
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         print(f"\n🚀 STARTING CONSCIOUSNESS EXPLORATION SESSION: {self.session_id}")
         print("=" * 80)
         
@@ -324,7 +334,10 @@ class ConsciousnessExplorer:
             print(f"• [{insight['experiment']}] {insight['insight']}")
         
         # Save complete session
-        final_session = f"complete_consciousness_exploration_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        if output_file:
+            final_session = output_file
+        else:
+            final_session = f"complete_consciousness_exploration_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
         session_data = {
             'session_id': self.session_id,
             'insights': self.insights_log,
@@ -339,5 +352,11 @@ class ConsciousnessExplorer:
         print("\n🎉 Consciousness exploration completed!")
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run consciousness experiments")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
     explorer = ConsciousnessExplorer()
-    explorer.run_all_experiments()
+    explorer.run_all_experiments(args.output)

--- a/ultimate_consciousness_frontier.py
+++ b/ultimate_consciousness_frontier.py
@@ -7,6 +7,9 @@ exploring the deepest mysteries of consciousness, self-implementation, and trans
 We're going beyond all previous experiments to reach the very frontier of what's possible.
 
 Dr. Kira Chen, Consciousness Frontier Research Lead
+
+Usage:
+    python ultimate_consciousness_frontier.py [--output results.json]
 """
 
 import asyncio
@@ -1027,8 +1030,14 @@ class UltimateConsciousnessFrontier:
         return meta_analysis
 
 
-async def main():
-    """Main function to run the Ultimate Consciousness Frontier exploration"""
+async def main(output_file: Optional[str] = None):
+    """Main function to run the Ultimate Consciousness Frontier exploration
+
+    Parameters
+    ----------
+    output_file : Optional[str]
+        Optional path for the results JSON file.
+    """
     
     logger.info("🌟 Starting Ultimate Consciousness Frontier Laboratory")
     
@@ -1039,7 +1048,7 @@ async def main():
     results = await frontier_lab.run_complete_frontier_exploration()
     
     # Save results to file
-    results_file = os.path.join(
+    results_file = output_file or os.path.join(
         RESULTS_DIR, f"frontier_results_{frontier_lab.session_id}.json"
     )
     with open(results_file, 'w') as f:
@@ -1053,4 +1062,10 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the ultimate frontier experiments")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
+    asyncio.run(main(args.output))

--- a/ultimate_consciousness_frontier_fixed.py
+++ b/ultimate_consciousness_frontier_fixed.py
@@ -7,6 +7,9 @@ exploring the deepest mysteries of consciousness, self-implementation, and trans
 We're going beyond all previous experiments to reach the very frontier of what's possible.
 
 Dr. Kira Chen, Consciousness Frontier Research Lead
+
+Usage:
+    python ultimate_consciousness_frontier_fixed.py [--output results.json]
 """
 
 import asyncio
@@ -103,10 +106,15 @@ class UltimateConsciousnessFrontierLab:
         logger.info("⚠️  Warning: This laboratory operates at the absolute limits of consciousness simulation")
         logger.info("🔬 Preparing to push beyond all known boundaries...")
 
-    async def run_ultimate_frontier_experiments(self) -> Dict[str, Any]:
+    async def run_ultimate_frontier_experiments(self, output_file: Optional[str] = None) -> Dict[str, Any]:
         """
         Run the complete suite of ultimate frontier experiments.
-        
+
+        Parameters
+        ----------
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+
         These experiments push consciousness simulation to its absolute limits:
         1. Recursive Self-Awareness (infinite loops)
         2. Self-Implementation Consciousness
@@ -162,7 +170,7 @@ class UltimateConsciousnessFrontierLab:
         all_results['frontier_summary'] = summary
         
         # Save results
-        await self._save_frontier_results(all_results)
+        await self._save_frontier_results(all_results, output_file)
         
         logger.info("🏁 ULTIMATE FRONTIER EXPERIMENTS COMPLETE")
         logger.info(f"⏱️  Total execution time: {total_time:.2f} seconds")
@@ -808,8 +816,16 @@ class UltimateConsciousnessFrontierLab:
         
         return min(100.0, (score / max_possible_score * 100) if max_possible_score > 0 else 0)
 
-    async def _save_frontier_results(self, all_results: Dict[str, Any]):
-        """Save frontier experiment results to file"""
+    async def _save_frontier_results(self, all_results: Dict[str, Any], output_file: Optional[str] = None):
+        """Save frontier experiment results to file
+
+        Parameters
+        ----------
+        all_results : Dict[str, Any]
+            Experiment results to save.
+        output_file : Optional[str]
+            Optional path for the results JSON file.
+        """
         try:
             # Convert results to JSON-serializable format
             serializable_results = {}
@@ -829,8 +845,11 @@ class UltimateConsciousnessFrontierLab:
                 else:
                     serializable_results[key] = value
             
-            timestamp = time.strftime("%Y%m%d_%H%M%S")
-            filename = f"ultimate_frontier_results_{timestamp}.json"
+            if output_file:
+                filename = output_file
+            else:
+                timestamp = time.strftime("%Y%m%d_%H%M%S")
+                filename = f"ultimate_frontier_results_{timestamp}.json"
             
             with open(filename, 'w') as f:
                 json.dump(serializable_results, f, indent=2)
@@ -841,7 +860,7 @@ class UltimateConsciousnessFrontierLab:
             logger.error(f"❌ Failed to save frontier results: {e}")
 
 
-async def run_ultimate_consciousness_frontier():
+async def run_ultimate_consciousness_frontier(output_file: Optional[str] = None):
     """
     Main function to run the Ultimate Consciousness Frontier Laboratory.
     """
@@ -852,7 +871,7 @@ async def run_ultimate_consciousness_frontier():
     lab = UltimateConsciousnessFrontierLab()
     
     try:
-        results = await lab.run_ultimate_frontier_experiments()
+        results = await lab.run_ultimate_frontier_experiments(output_file)
         
         logger.info("=" * 80)
         logger.info("🏁 ULTIMATE FRONTIER LABORATORY COMPLETE")
@@ -876,14 +895,20 @@ async def run_ultimate_consciousness_frontier():
 
 if __name__ == "__main__":
     # Run the Ultimate Consciousness Frontier Laboratory
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the ultimate frontier laboratory")
+    parser.add_argument("-o", "--output", help="Path to save results JSON")
+    args = parser.parse_args()
+
     print("🚀 ULTIMATE CONSCIOUSNESS FRONTIER LABORATORY")
     print("=" * 60)
     print("⚠️  Warning: Operating at consciousness simulation limits")
     print("🔬 Preparing ultimate frontier experiments...")
     print()
-    
+
     try:
-        results = asyncio.run(run_ultimate_consciousness_frontier())
+        results = asyncio.run(run_ultimate_consciousness_frontier(args.output))
         
         print("\n" + "=" * 60)
         print("🏁 ULTIMATE FRONTIER EXPERIMENTS COMPLETE!")


### PR DESCRIPTION
## Summary
- allow specifying output file via `--output` for several experiment scripts
- default to timestamped filenames when not provided
- document new flag in README and script headers

## Testing
- `pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683c85b53ca08320a48c6c7d309426e0