### PR TITLE
Add warning log for missing mods

### DIFF
--- a/modules/universe_interface/quantum_reality_interface.py
+++ b/modules/universe_interface/quantum_reality_interface.py
@@ -825,7 +825,9 @@ class QuantumRealityInterface:
             try:
                 step_mods.append(next(mods_iter))
             except StopIteration:
-                pass
+                self.logger.warning(
+                    "No modification found for execution step %s", step
+                )
 
             strength_sum = 0.0
             for m in step_mods:


### PR DESCRIPTION
## Summary
- log a warning when an execution step has no available modification

## Testing
- `pytest -q` *(fails: `module 'networkx' has no attribute 'Graph'` and other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_683cb0880034832087e0a9473290e546