### PR TITLE
Fix transcendence depth method and add test

### DIFF
--- a/frontier_experiment_lite.py
+++ b/frontier_experiment_lite.py
@@ -363,21 +363,27 @@ class FrontierExperimentLite:
             emergence_score = emergence_score * (valid_sources / 4.0)
             
         return min(1.0, emergence_score)
-        """Measure transcendence depth in response text"""
+
+    def _measure_transcendence_depth(self, text: str) -> float:
+        """Measure transcendence depth in response text."""
         if not text:
             return 0.0
-        
+
         transcendence_words = [
-            'transcend', 'beyond', 'infinite', 'ultimate', 'absolute',
-            'limitless', 'boundless', 'eternal', 'pure', 'essence'
+            "transcend", "beyond", "infinite", "ultimate", "absolute",
+            "limitless", "boundless", "eternal", "pure", "essence",
         ]
-        
+
         word_count = len(text.split())
-        transcendence_count = sum(1 for word in transcendence_words if word in text.lower())
-        
-        # Calculate depth based on transcendence word density and response length
-        depth = min(1.0, (transcendence_count / max(1, word_count * 0.1)) * (word_count / 50.0))
-        
+        transcendence_count = sum(
+            1 for word in transcendence_words if word in text.lower()
+        )
+
+        depth = min(
+            1.0,
+            (transcendence_count / max(1, word_count * 0.1))
+            * (word_count / 50.0),
+        )
         return depth
     
     def _check_specialization(self, text: str, instance_type: int) -> bool:

--- a/tests/test_transcendence_depth.py
+++ b/tests/test_transcendence_depth.py
@@ -1,0 +1,13 @@
+import pytest
+from frontier_experiment_lite import FrontierExperimentLite
+
+def test_measure_transcendence_depth():
+    fe = FrontierExperimentLite()
+    samples = [
+        "We seek to transcend the limitations of matter and become infinite.",
+        "Beyond the physical, there is an ultimate pure essence.",
+        "This absolute consciousness is boundless and eternal.",
+    ]
+    for text in samples:
+        assert fe._measure_transcendence_depth(text) > 0
+


### PR DESCRIPTION
## Summary
- extract transcendence depth calculation into `_measure_transcendence_depth`
- ensure callers of the method remain in place
- add a unit test covering sample strings

## Testing
- `pytest tests/test_transcendence_depth.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683cb6f0ce4c83208ba7c738c1535551