### PR TITLE
Add quantum plan constants to config and interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,10 @@ Important keys include:
 * ``consciousness_physics`` – physical constants used by advanced modules
   (``information_transfer_rate``, ``consciousness_bandwidth``,
   ``info_reality_bridge_bandwidth``, ``info_reality_bridge_fidelity``).
-* ``quantum`` – quantum communication parameters
+* ``quantum`` – quantum communication and planning parameters
   (``communication_bandwidth``, ``teleportation_fidelity``,
-  ``fidelity_threshold``).
+  ``fidelity_threshold``, ``plan_step_duration_base``, ``plan_energy_base``,
+  ``plan_energy_scale``).
 * ``reality_interface`` – limits for information/matter interfaces
   (``energy_limit``, ``info_matter_bandwidth``, ``info_matter_fidelity``).
 

--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,9 @@ quantum:
   communication_bandwidth: 1e6
   teleportation_fidelity: 0.9
   fidelity_threshold: 0.99
+  plan_step_duration_base: 0.1
+  plan_energy_base: 1e9
+  plan_energy_scale: 1e10
 
 reality_interface:
   energy_limit: 1e50

--- a/modules/universe_interface/quantum_reality_interface.py
+++ b/modules/universe_interface/quantum_reality_interface.py
@@ -24,6 +24,9 @@ FIDELITY_THRESHOLD = float(get_config_value("quantum.fidelity_threshold", 0.99))
 INFO_MATTER_BANDWIDTH = float(get_config_value("reality_interface.info_matter_bandwidth", 1e20))
 INFO_MATTER_FIDELITY = float(get_config_value("reality_interface.info_matter_fidelity", 0.99))
 ENERGY_LIMIT = float(get_config_value("reality_interface.energy_limit", 1e50))
+PLAN_STEP_DURATION_BASE = float(get_config_value("quantum.plan_step_duration_base", 0.1))
+PLAN_ENERGY_BASE = float(get_config_value("quantum.plan_energy_base", 1e9))
+PLAN_ENERGY_SCALE = float(get_config_value("quantum.plan_energy_scale", 1e10))
 
 
 class QuantumOperation(Enum):
@@ -834,8 +837,8 @@ class QuantumRealityInterface:
             plan.append({
                 "step": step,
                 "modifications": step_mods,
-                "duration": 0.1 * (len(step_mods) or 1),
-                "energy_required": 1e9 + strength_sum * 1e10,
+                "duration": PLAN_STEP_DURATION_BASE * (len(step_mods) or 1),
+                "energy_required": PLAN_ENERGY_BASE + strength_sum * PLAN_ENERGY_SCALE,
                 "rollback_point": program.rollback_capability,
             })
             


### PR DESCRIPTION
## Summary
- expose plan_step_duration_base, plan_energy_base, plan_energy_scale in config
- consume new configuration values in `quantum_reality_interface`
- document quantum planning parameters in README

## Testing
- `pytest -q` *(fails: networkx missing and other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_683cc1eed08c8320b0d5cb50c49b05fb