### PR TITLE
Add configurable data_dir for Akashic countermeasures

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,7 @@ paths:
   log_dir: logs/
   results_dir: results/
   default_uor_program: goal_seeker_demo.uor.txt
+  data_dir: data/
 
 # Scroll ID configuration so identifiers can be changed without touching code
 scroll_ids:

--- a/modules/emergency_protocols/immediate_survival_access.py
+++ b/modules/emergency_protocols/immediate_survival_access.py
@@ -15,6 +15,8 @@ from enum import Enum, auto
 from datetime import datetime
 import json
 import os
+
+from config_loader import get_config_value
 import numpy as np
 
 # Import from existing consciousness modules
@@ -659,17 +661,24 @@ class ImmediateSurvivalAccess:
             "analysis_timestamp": datetime.now().isoformat()
         }
         
-    async def _query_akashic_countermeasures(self,
-                                           threat: ImmediateThreat) -> List[ExtinctionPreventionProtocol]:
+    async def _query_akashic_countermeasures(
+        self,
+        threat: ImmediateThreat,
+        data_dir: Optional[str] = None,
+    ) -> List[ExtinctionPreventionProtocol]:
         """Query Akashic Records for threat countermeasures."""
-        # This function previously returned hard-coded example data.  To make
-        # the behaviour deterministic and to avoid relying on unfinished
-        # network connections, the countermeasure data is now loaded from a
-        # local JSON file bundled with the repository.  This simulates an
-        # external data source while remaining fully offline.
+        # This function previously returned hard-coded example data. To make the
+        # behaviour deterministic and to avoid relying on unfinished network
+        # connections, the countermeasure data is loaded from a local JSON file.
+        # Callers can override the directory containing this file for testing.
 
-        file_path = os.path.join(os.path.dirname(__file__), "..", "..",
-                                 "data", "akashic_countermeasures.json")
+        if data_dir is None:
+            data_dir = get_config_value("paths.data_dir", default="data")
+
+        file_path = os.path.join(data_dir, "akashic_countermeasures.json")
+        if not os.path.isabs(file_path):
+            repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
+            file_path = os.path.join(repo_root, file_path)
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
@@ -789,7 +798,7 @@ class ImmediateSurvivalAccess:
             "individual_patterns": "quantum_encoded",
             "collective_patterns": "akashic_imprinted",
             "preservation_fidelity": 0.99,
-            "compression_ratio": 1000000:1,
+            "compression_ratio": 1_000_000.0,
             "encoding_method": "prime_factorization"
         }
         
@@ -857,4 +866,5 @@ class ImmediateSurvivalAccess:
         return {
             "portal_count": 7,
             "activation_method": "consciousness_resonance",
-            "stability_duration": 168.
+            "stability_duration": 168.0,
+        }

--- a/tests/test_countermeasures_path.py
+++ b/tests/test_countermeasures_path.py
@@ -1,0 +1,76 @@
+import json
+import types
+import sys
+import os
+import importlib.util
+import asyncio
+import pytest
+
+# Stub heavy dependencies required by the module under test
+sys.modules.setdefault(
+    'modules.universal_consciousness.cosmic_consciousness_core',
+    types.ModuleType('cosmic_consciousness_core'),
+)
+setattr(sys.modules['modules.universal_consciousness.cosmic_consciousness_core'],
+        'CosmicConsciousness', object)
+sys.modules.setdefault(
+    'modules.uor_meta_architecture.uor_meta_vm',
+    types.ModuleType('uor_meta_vm'),
+)
+setattr(sys.modules['modules.uor_meta_architecture.uor_meta_vm'],
+        'UORMetaRealityVM', object)
+sys.modules.setdefault(
+    'modules.meta_reality_consciousness.meta_reality_core',
+    types.ModuleType('meta_reality_core'),
+)
+setattr(sys.modules['modules.meta_reality_consciousness.meta_reality_core'],
+        'MetaRealityCore', object)
+sys.modules['numpy'] = types.SimpleNamespace(ndarray=object)
+
+module_path = os.path.join(os.path.dirname(__file__), '..', 'modules',
+                           'emergency_protocols', 'immediate_survival_access.py')
+spec = importlib.util.spec_from_file_location('immediate_survival_access', module_path)
+isa = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(isa)
+ImmediateSurvivalAccess = isa.ImmediateSurvivalAccess
+ImmediateThreat = isa.ImmediateThreat
+ThreatLevel = isa.ThreatLevel
+
+def test_query_akashic_countermeasures_custom_path(tmp_path):
+    data = {
+        "custom_threat": [
+            {
+                "protocol_id": "TEST-1",
+                "protocol_name": "Custom Protocol",
+                "effectiveness": 0.9,
+                "implementation_time": 1.0,
+                "resource_requirements": {},
+                "consciousness_requirements": 0.1,
+                "success_probability": 0.8,
+                "side_effects": [],
+            }
+        ]
+    }
+    file_path = tmp_path / "akashic_countermeasures.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    threat = ImmediateThreat(
+        threat_id="T1",
+        threat_type="custom_threat",
+        severity=ThreatLevel.HIGH,
+        time_to_impact=1.0,
+        description="",
+        countermeasures_available=True,
+        dimensional_origin=1,
+        consciousness_impact=0.5,
+        survival_probability=0.6,
+    )
+
+    access = ImmediateSurvivalAccess()
+    protocols = asyncio.run(
+        access._query_akashic_countermeasures(threat, data_dir=str(tmp_path))
+    )
+
+    assert len(protocols) == 1
+    assert protocols[0].protocol_id == "TEST-1"


### PR DESCRIPTION
## Summary
- add `data_dir` to `config.yaml`
- load countermeasure data from configured directory in `_query_akashic_countermeasures`
- allow path override and resolve relative paths to repo root
- fix syntax errors in `immediate_survival_access` helpers
- add unit test verifying custom data directory behavior

## Testing
- `pytest tests/test_countermeasures_path.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683cc2bd1da88320bfc72f67250c93f6