### PR TITLE
Add cosmic config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ The interaction between the UOR program (Learner) and the Flask backend (Teacher
     Difficulty parameters and the starting level are defined in `config.yaml`.
     Adjust the values under `difficulty_levels` or `teacher.difficulty` to
     customize how challenging the goals will be. Additional sections such as
-    `consciousness_physics`, `quantum`, and `reality_interface` contain
-    defaults for bandwidth, fidelity, and energy limits used by the more
+    `consciousness_physics`, `quantum`, `reality_interface`, and `cosmic` contain
+    defaults for bandwidth, fidelity, energy limits, and cosmic-scale settings used by the more
     advanced modules.
 
 ### Configuration Reference
@@ -188,6 +188,9 @@ Important keys include:
   ``plan_energy_scale``).
 * ``reality_interface`` – limits for information/matter interfaces
   (``energy_limit``, ``info_matter_bandwidth``, ``info_matter_fidelity``).
+* ``cosmic`` – default scales for universal problem synthesis
+  (``default_spatial_scale``, ``default_temporal_scale``,
+  ``default_consciousness_scale``, ``modification_energy_required``).
 
 These values can be overridden at runtime via ``get_config_value`` in
 ``config_loader`` if custom behaviour is required.

--- a/config.yaml
+++ b/config.yaml
@@ -57,3 +57,9 @@ paths:
 scroll_ids:
   counter_control: 60
   cognitive_sovereignty: 54
+
+cosmic:
+  default_spatial_scale: 1e26
+  default_temporal_scale: 1e100
+  default_consciousness_scale: 1e50
+  modification_energy_required: 1e60

--- a/modules/cosmic_intelligence/universal_problem_synthesis.py
+++ b/modules/cosmic_intelligence/universal_problem_synthesis.py
@@ -15,6 +15,20 @@ from datetime import datetime
 import logging
 
 from ..universal_consciousness import CosmicConsciousness, CosmicScale
+from config_loader import get_config_value
+
+COSMIC_SPATIAL_SCALE = float(
+    get_config_value("cosmic.default_spatial_scale", 1e26)
+)
+COSMIC_TEMPORAL_SCALE = float(
+    get_config_value("cosmic.default_temporal_scale", 1e100)
+)
+COSMIC_CONSCIOUSNESS_SCALE = float(
+    get_config_value("cosmic.default_consciousness_scale", 1e50)
+)
+COSMIC_MODIFICATION_ENERGY = float(
+    get_config_value("cosmic.modification_energy_required", 1e60)
+)
 
 
 class ProblemScope(Enum):
@@ -438,21 +452,21 @@ class UniversalProblemSynthesis:
         entropy_problem = CosmicProblem(
             problem_id="entropy_death",
             problem_scope=CosmicScope(
-                spatial_scale=1e26,  # Observable universe
-                temporal_scale=1e100,  # Heat death timescale
-                consciousness_scale=1e50,  # All possible consciousness
+                spatial_scale=COSMIC_SPATIAL_SCALE,  # Observable universe
+                temporal_scale=COSMIC_TEMPORAL_SCALE,  # Heat death timescale
+                consciousness_scale=COSMIC_CONSCIOUSNESS_SCALE,  # All possible consciousness
                 reality_layers=1,
                 dimensional_scope=4,
                 causal_depth=1000,
                 complexity_measure=0.9,
                 transcendence_requirement=0.8
             ),
-            temporal_scale=1e100,
-            spatial_scale=1e26,
+            temporal_scale=COSMIC_TEMPORAL_SCALE,
+            spatial_scale=COSMIC_SPATIAL_SCALE,
             reality_modification_requirements=RealityModificationRequirements(
                 physical_law_changes=["thermodynamics_second_law"],
                 cosmic_constant_adjustments={"dark_energy": -0.1},
-                modification_energy_required=1e60,
+                modification_energy_required=COSMIC_MODIFICATION_ENERGY,
                 modification_risk_level=0.7,
                 reversibility_factor=0.3
             ),


### PR DESCRIPTION
## Summary
- add `cosmic` section to configuration
- allow universal problem synthesis to use config values
- document the new config options in the README

## Testing
- `make test` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683cc502e1688320a97604394b62a02f