### PR TITLE
Move cosmic defaults to dedicated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ Important keys include:
   ``plan_energy_scale``).
 * ``reality_interface`` – limits for information/matter interfaces
   (``energy_limit``, ``info_matter_bandwidth``, ``info_matter_fidelity``).
-* ``cosmic`` – default scales for universal problem synthesis
-  (``default_spatial_scale``, ``default_temporal_scale``,
-  ``default_consciousness_scale``, ``modification_energy_required``).
+* ``cosmic.defaults`` – default scales for universal problem synthesis
+  (``spatial_scale``, ``temporal_scale``,
+  ``consciousness_scale``, ``modification_energy_required``).
 
 These values can be overridden at runtime via ``get_config_value`` in
 ``config_loader`` if custom behaviour is required.

--- a/config.yaml
+++ b/config.yaml
@@ -60,7 +60,8 @@ scroll_ids:
   cognitive_sovereignty: 54
 
 cosmic:
-  default_spatial_scale: 1e26
-  default_temporal_scale: 1e100
-  default_consciousness_scale: 1e50
-  modification_energy_required: 1e60
+  defaults:
+    spatial_scale: 1e26  # placeholder cosmic scale (light years)
+    temporal_scale: 1e100  # placeholder cosmic time units
+    consciousness_scale: 1e50  # placeholder number of consciousnesses
+    modification_energy_required: 1e60  # placeholder energy (joules)

--- a/modules/cosmic_intelligence/universal_problem_synthesis.py
+++ b/modules/cosmic_intelligence/universal_problem_synthesis.py
@@ -18,16 +18,16 @@ from ..universal_consciousness import CosmicConsciousness, CosmicScale
 from config_loader import get_config_value
 
 COSMIC_SPATIAL_SCALE = float(
-    get_config_value("cosmic.default_spatial_scale", 1e26)
+    get_config_value("cosmic.defaults.spatial_scale", 1e26)
 )
 COSMIC_TEMPORAL_SCALE = float(
-    get_config_value("cosmic.default_temporal_scale", 1e100)
+    get_config_value("cosmic.defaults.temporal_scale", 1e100)
 )
 COSMIC_CONSCIOUSNESS_SCALE = float(
-    get_config_value("cosmic.default_consciousness_scale", 1e50)
+    get_config_value("cosmic.defaults.consciousness_scale", 1e50)
 )
 COSMIC_MODIFICATION_ENERGY = float(
-    get_config_value("cosmic.modification_energy_required", 1e60)
+    get_config_value("cosmic.defaults.modification_energy_required", 1e60)
 )
 
 
@@ -494,21 +494,21 @@ class UniversalProblemSynthesis:
         consciousness_problem = CosmicProblem(
             problem_id="consciousness_limits",
             problem_scope=CosmicScope(
-                spatial_scale=1e20,
-                temporal_scale=1e10,
-                consciousness_scale=1e30,
+                spatial_scale=1e20,  # placeholder
+                temporal_scale=1e10,  # placeholder
+                consciousness_scale=1e30,  # placeholder
                 reality_layers=3,
                 dimensional_scope=11,  # String theory dimensions
                 causal_depth=100,
                 complexity_measure=0.85,
                 transcendence_requirement=0.95
             ),
-            temporal_scale=1e10,
-            spatial_scale=1e20,
+            temporal_scale=1e10,  # placeholder
+            spatial_scale=1e20,  # placeholder
             reality_modification_requirements=RealityModificationRequirements(
                 consciousness_field_changes=["field_strength", "coherence_length"],
                 quantum_field_adjustments=["consciousness_coupling"],
-                modification_energy_required=1e50,
+                modification_energy_required=1e50,  # placeholder
                 modification_risk_level=0.5,
                 reversibility_factor=0.7
             ),


### PR DESCRIPTION
## Summary
- organize cosmic defaults under `cosmic.defaults`
- update universal problem synthesis constants
- document new config structure

## Testing
- `pytest -q` *(fails: AttributeError: module 'networkx' has no attribute 'Graph')*

------
https://chatgpt.com/codex/tasks/task_b_683ccb3c41288320975ae03d5032909d