### PR TITLE
Make countermeasure file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Important keys include:
 * ``teacher.difficulty`` – starting difficulty level for the adaptive teacher.
 * ``teacher.alert_email`` – address to notify on critical errors (overridden via
   the ``ALERT_EMAIL`` environment variable).
+* ``paths.countermeasures_file`` – JSON file with emergency countermeasures
+  (overridden via ``PATHS_COUNTERMEASURES_FILE``).
 * ``difficulty_levels`` – per-level settings such as ``range_max`` and
   thresholds.
 * ``benchmark.iterations`` – iteration count for benchmarking utilities.

--- a/config.yaml
+++ b/config.yaml
@@ -64,6 +64,7 @@ paths:
   results_dir: results/
   default_uor_program: goal_seeker_demo.uor.txt
   data_dir: data/
+  countermeasures_file: data/akashic_countermeasures.json
 
 # Scroll ID configuration so identifiers can be changed without touching code
 scroll_ids:

--- a/modules/emergency_protocols/immediate_survival_access.py
+++ b/modules/emergency_protocols/immediate_survival_access.py
@@ -664,18 +664,19 @@ class ImmediateSurvivalAccess:
     async def _query_akashic_countermeasures(
         self,
         threat: ImmediateThreat,
-        data_dir: Optional[str] = None,
+        file_path: Optional[str] = None,
     ) -> List[ExtinctionPreventionProtocol]:
         """Query Akashic Records for threat countermeasures."""
         # This function previously returned hard-coded example data. To make the
         # behaviour deterministic and to avoid relying on unfinished network
         # connections, the countermeasure data is loaded from a local JSON file.
-        # Callers can override the directory containing this file for testing.
+        # Callers can override the path to this file for testing.
 
-        if data_dir is None:
-            data_dir = get_config_value("paths.data_dir", default="data")
-
-        file_path = os.path.join(data_dir, "akashic_countermeasures.json")
+        if file_path is None:
+            file_path = get_config_value(
+                "paths.countermeasures_file",
+                default="data/akashic_countermeasures.json",
+            )
         if not os.path.isabs(file_path):
             repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
             file_path = os.path.join(repo_root, file_path)

--- a/tests/test_countermeasures_path.py
+++ b/tests/test_countermeasures_path.py
@@ -69,8 +69,48 @@ def test_query_akashic_countermeasures_custom_path(tmp_path):
 
     access = ImmediateSurvivalAccess()
     protocols = asyncio.run(
-        access._query_akashic_countermeasures(threat, data_dir=str(tmp_path))
+        access._query_akashic_countermeasures(threat, file_path=str(file_path))
     )
 
     assert len(protocols) == 1
     assert protocols[0].protocol_id == "TEST-1"
+
+
+def test_query_akashic_countermeasures_env_var(tmp_path, monkeypatch):
+    data = {
+        "env_threat": [
+            {
+                "protocol_id": "ENV-1",
+                "protocol_name": "Env Protocol",
+                "effectiveness": 0.7,
+                "implementation_time": 2.0,
+                "resource_requirements": {},
+                "consciousness_requirements": 0.2,
+                "success_probability": 0.5,
+                "side_effects": [],
+            }
+        ]
+    }
+    file_path = tmp_path / "env_countermeasures.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    monkeypatch.setenv("PATHS_COUNTERMEASURES_FILE", str(file_path))
+
+    threat = ImmediateThreat(
+        threat_id="T2",
+        threat_type="env_threat",
+        severity=ThreatLevel.HIGH,
+        time_to_impact=1.0,
+        description="",
+        countermeasures_available=True,
+        dimensional_origin=1,
+        consciousness_impact=0.5,
+        survival_probability=0.6,
+    )
+
+    access = ImmediateSurvivalAccess()
+    protocols = asyncio.run(access._query_akashic_countermeasures(threat))
+
+    assert len(protocols) == 1
+    assert protocols[0].protocol_id == "ENV-1"


### PR DESCRIPTION
## Summary
- allow overriding path to Akashic countermeasures JSON
- read new value from `paths.countermeasures_file`
- describe config key and env variable in README
- test explicit path argument and env variable override

## Testing
- `pytest tests/test_countermeasures_path.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683cd7334f908320a98e70cbd076bb06